### PR TITLE
Alexandra mvc

### DIFF
--- a/foundry/app/assets/javascripts/authoring/events.js
+++ b/foundry/app/assets/javascripts/authoring/events.js
@@ -611,6 +611,7 @@ function drawCollabBtn(eventObj, firstTime) {
 }
 
 function drawMemberLines(eventObj) {
+    console.log("drawing member lines for ", eventObj);
     var x_offset = 8; // unique for member lines
     var width = getWidth(eventObj) - 8;
 
@@ -621,6 +622,7 @@ function drawMemberLines(eventObj) {
     // figure out if first time or not for each member line
     for(var i=0;i<members.length;i++){
         var existingLine = task_g.selectAll("#event_" + groupNum + "_eventMemLine_" + (i+1));
+        console.log("EXISTING LINE", existingLine);
         var y_offset = 60 + (i*8); // unique for member lines
         if(existingLine[0].length == 0){ // first time
             var member = getMemberById(members[i]);
@@ -765,7 +767,8 @@ function drawEachCollab(eventObj, firstTime){
 }
 
 //Creates graphical elements from array of data (task_rectangles)
-function drawEvent(eventObj, firstTime) {    
+function drawEvent(eventObj, firstTime) { 
+    console.log("redrawing event");   
     drawG(eventObj, firstTime);
     drawMainRect(eventObj, firstTime);
     drawRightDragBar(eventObj, firstTime);
@@ -826,6 +829,17 @@ function deleteEventMember(eventId, memberNum, memberName) {
         }
     }
 }
+
+//Remove all the lines from a given event
+function removeAllMemberLines(eventObj){
+    var groupNum = eventObj["id"];
+    var members = eventObj["members"];
+    var task_g = getTaskGFromGroupNum(groupNum);
+
+    for(var i=0;i<members.length;i++){
+        task_g.selectAll("#event_" + groupNum + "_eventMemLine_" + (i+1)).remove();
+    }
+};
 
 //Updates the physical task rectangle representation of start and duration, also update JSON
 function updateTime(idNum) {

--- a/foundry/app/assets/javascripts/authoring/popovers.js
+++ b/foundry/app/assets/javascripts/authoring/popovers.js
@@ -181,8 +181,7 @@ function readOnlyPopoverObj(ev) {
 function drawPopover(eventObj, editable, show) {
    var groupNum = eventObj.id;
      // draw it
-    var data = getPopoverDataFromGroupNum(groupNum); //SOMETHING WRONG
-    console.log("data value in drawPopover", data);
+    var data = getPopoverDataFromGroupNum(groupNum); //SOMETHING WRONG, RETURNS UNDEFINED
     if(!data){ // popover not set yet
         if(editable){
             setPopoverOnTask(groupNum, editablePopoverObj(eventObj));
@@ -273,7 +272,6 @@ function saveEventInfo (popId) {
     //Update members of event
     flashTeamsJSON["events"][indexOfJSON].members = [];
     for (var i = 0; i<flashTeamsJSON["members"].length; i++) {
-        console.log("checking member", i);
         var member = flashTeamsJSON["members"][i];
         var memberId = member.id;
         var checkbox = $("#event" + popId + "member" + i + "checkbox")[0];
@@ -290,7 +288,6 @@ function saveEventInfo (popId) {
     if (newMin == "") newMin = parseInt($("#minutes_" + popId)[0].placeholder);
     newMin = Math.round(parseInt(newMin)/15) * 15;
     var newWidth = (newHours * 100) + (newMin/15*25);
-    console.log("HI ALEXANDRA");
   
     //Update JSON
     var indexOfJSON = getEventJSONIndex(popId);

--- a/foundry/app/assets/javascripts/authoring/popovers.js
+++ b/foundry/app/assets/javascripts/authoring/popovers.js
@@ -181,7 +181,8 @@ function readOnlyPopoverObj(ev) {
 function drawPopover(eventObj, editable, show) {
    var groupNum = eventObj.id;
      // draw it
-    var data = getPopoverDataFromGroupNum(groupNum);
+    var data = getPopoverDataFromGroupNum(groupNum); //SOMETHING WRONG
+    console.log("data value in drawPopover", data);
     if(!data){ // popover not set yet
         if(editable){
             setPopoverOnTask(groupNum, editablePopoverObj(eventObj));

--- a/foundry/app/assets/javascripts/authoring/popovers.js
+++ b/foundry/app/assets/javascripts/authoring/popovers.js
@@ -233,32 +233,11 @@ function saveEventInfo (popId) {
     var eventNotes = $("#notes_" + popId).val();
     var driId = getDRI(popId);
    
-    //Add Event Members, see checkboxes
     var indexOfJSON = getEventJSONIndex(popId);
-    //old version of code to update members 
-    /*for (i = 0; i<flashTeamsJSON["members"].length; i++) {
-        //START HERE
-        var memberName = flashTeamsJSON["members"][i].role;
-        if ($("#event" + popId + "member" + i + "checkbox")[0] == undefined) return; //No members?
-        if ( $("#event" + popId + "member" + i + "checkbox")[0].checked == true) {
-            if (flashTeamsJSON["events"][indexOfJSON].members.indexOf(memberName) == -1) {
-                addEventMember(popId, i);
-            }
-        } else {
-            for (j = 0; j<flashTeamsJSON["events"][indexOfJSON].members.length; j++) {
-                if (flashTeamsJSON["events"][indexOfJSON].members[j] == flashTeamsJSON["members"][i].role) {
-                    var memId = flashTeamsJSON["members"][i].id;
-                    flashTeamsJSON["events"][indexOfJSON].members.splice(j, 1);
-                    $("#event_" + popId + "_eventMemLine_" + memId).remove(); //THIS IS THE PROBLEM, j
-                }
-            }
-        }
-    }*/
-
     var ev = flashTeamsJSON["events"][indexOfJSON];
 
-    //update members of event
-    flashTeamsJSON["events"][indexOfJSON].members =[];
+    //Update members of event
+    flashTeamsJSON["events"][indexOfJSON].members = [];
     for (var i = 0; i<flashTeamsJSON["members"].length; i++) {
         var member = flashTeamsJSON["members"][i];
         var memberId = member.id;

--- a/foundry/app/assets/javascripts/authoring/popovers.js
+++ b/foundry/app/assets/javascripts/authoring/popovers.js
@@ -289,6 +289,7 @@ function saveEventInfo (popId) {
     if (newMin == "") newMin = parseInt($("#minutes_" + popId)[0].placeholder);
     newMin = Math.round(parseInt(newMin)/15) * 15;
     var newWidth = (newHours * 100) + (newMin/15*25);
+    console.log("HI ALEXANDRA");
   
     //Update JSON
     var indexOfJSON = getEventJSONIndex(popId);
@@ -338,11 +339,9 @@ function getDRI(groupNum) {
     var driId;
    
     if (dri == null){
-	     //console.log("dri ID is null");
 	     driId = 0;       
     }
     else{
-	    //console.log("The dri ID is:" + driId);
 	    var driId = dri.value;    
     }
     return driId;
@@ -351,15 +350,15 @@ function getDRI(groupNum) {
 //Adds member checkboxes onto the popover of an event, checks if a member is involved in event
 function writeEventMembers(eventObj) {
     var memberString = "";
-    var indexOfJSON = getEventJSONIndex(eventObj["id"]);
+    var evMembers = eventObj.members;
+
     if (flashTeamsJSON["members"].length == 0) return "No Team Members";
     for (i = 0; i<flashTeamsJSON["members"].length; i++) {
-        var memberId = flashTeamsJSON["members"][i].id;
+        var memberSearchId = flashTeamsJSON["members"][i].id;
         var memberName = flashTeamsJSON["members"][i].role;
-        var memberUniq = flashTeamsJSON["members"][i].uniq;
         var found = false;
-        for (j = 0; j<flashTeamsJSON["events"][indexOfJSON].members.length; j++) {
-            if (flashTeamsJSON["events"][indexOfJSON].members[j].uniq === memberUniq) {
+        for (j = 0; j<evMembers.length; j++) {
+            if (evMembers[j] == memberSearchId) {
                 memberString += '<input type="checkbox" id="event' + eventObj["id"] + 'member' 
                     + i + 'checkbox" checked="true">' + memberName + "   <br>";
                 found = true;

--- a/foundry/app/assets/javascripts/authoring/popovers.js
+++ b/foundry/app/assets/javascripts/authoring/popovers.js
@@ -44,7 +44,7 @@ function editablePopoverObj(eventObj) {
         +'Minutes: <input type = "number" id = "minutes_' + groupNum + '" placeholder="'+minutesLeft
             +'" style="width:35px" min="0" step="15" max="45"/><br>'
         +'</td></tr><tr><td><b>Members</b><br> <div id="event' + groupNum + 'memberList">'
-            + writeEventMembers(groupNum) +'</div>'
+            + writeEventMembers(eventObj) +'</div>'
         +'</td><td><b>Directly-Responsible Individual</b><br><select class="driInput"' 
             +' name="driName" id="driEvent_' + groupNum + '"' 
         + 'onchange="getDRI('+groupNum + ')">'+ writeDRIMembers(groupNum,dri_id) +'</select>'
@@ -312,33 +312,25 @@ function getDRI(groupNum) {
 }
 
 //Adds member checkboxes onto the popover of an event, checks if a member is involved in event
-function writeEventMembers(idNum) {
-    var indexOfJSON = getEventJSONIndex(idNum);
+function writeEventMembers(eventObj) {
     var memberString = "";
-    
-    if (flashTeamsJSON["members"].length == 0) return "No Team Members";
-    for (var i = 0; i<flashTeamsJSON["members"].length; i++) {
+    for (i = 0; i < flashTeamsJSON["members"].length; i++) {
+        var memberId = flashTeamsJSON["members"][i].id;
         var memberName = flashTeamsJSON["members"][i].role;
-
         var found = false;
-
-        for (var j = 0; j<flashTeamsJSON["events"][indexOfJSON].members.length; j++) {
-            var member = getMemberById(flashTeamsJSON["events"][indexOfJSON].members[j]);
-            //console.log("first: " + member.role);
-            //console.log("second: " + memberName);
-            if (member.role == memberName) {
-                //OLD CODE: onclick="if(this.checked){addEventMember(' + event_counter + ', ' +  i + ')}"
-                memberString += '<input type="checkbox" id="event' + idNum + 'member' 
+        for (j = 0; j < eventObj.members.length; j++) {
+            var evMemId = eventObj.members[i];
+            if (evMemId == memberId) {
+                memberString += '<input type="checkbox" id="event' + eventObj.id + 'member' 
                     + i + 'checkbox" checked="true">' + memberName + "   <br>";
                 found = true;
                 break;
             }
         }
-
         if (!found) {
-            memberString +=  '<input type="checkbox" id="event' + idNum 
-                + 'member' + i + 'checkbox">' + memberName + "   <br>"; 
-        }      
+            memberString +=  '<input type="checkbox" id="event' + eventObj.id 
+                + 'member' + i + 'checkbox">' + memberName + "   <br>";
+        }
     }
     return memberString;
 };

--- a/foundry/app/assets/javascripts/authoring/popovers.js
+++ b/foundry/app/assets/javascripts/authoring/popovers.js
@@ -214,6 +214,7 @@ var getPopoverDataFromGroupNum = function(groupNum){
 //Called when the user clicks save on an event popover, grabs new info from user and updates 
 //both the info in the popover and the event rectangle graphics
 function saveEventInfo (popId) {
+    console.log("Event saving");
     //Update title
     var newTitle = $("#eventName_" + popId).val();
     if (!newTitle == "") $("#title_text_" + popId).text(newTitle);
@@ -236,17 +237,20 @@ function saveEventInfo (popId) {
     var indexOfJSON = getEventJSONIndex(popId);
     var ev = flashTeamsJSON["events"][indexOfJSON];
 
+
     //Update members of event
     flashTeamsJSON["events"][indexOfJSON].members = [];
     for (var i = 0; i<flashTeamsJSON["members"].length; i++) {
         var member = flashTeamsJSON["members"][i];
         var memberId = member.id;
         var checkbox = $("#event" + popId + "member" + i + "checkbox")[0];
-        if (checkbox == undefined) return;
+        if (checkbox == undefined) continue;
         if (checkbox.checked == true) {
-            ev.members.push(memberId);
+            console.log("found you", i);
+            ev.members.push(memberId); //Update JSON
         }
     }
+    console.log("all the members", ev.members);
 
     //Update width
     var newHours = $("#hours_" + popId).val();
@@ -314,23 +318,25 @@ function getDRI(groupNum) {
 //Adds member checkboxes onto the popover of an event, checks if a member is involved in event
 function writeEventMembers(eventObj) {
     var memberString = "";
-    for (i = 0; i < flashTeamsJSON["members"].length; i++) {
+    var indexOfJSON = getEventJSONIndex(eventObj["id"]);
+    if (flashTeamsJSON["members"].length == 0) return "No Team Members";
+    for (i = 0; i<flashTeamsJSON["members"].length; i++) {
         var memberId = flashTeamsJSON["members"][i].id;
         var memberName = flashTeamsJSON["members"][i].role;
+        var memberUniq = flashTeamsJSON["members"][i].uniq;
         var found = false;
-        for (j = 0; j < eventObj.members.length; j++) {
-            var evMemId = eventObj.members[i];
-            if (evMemId == memberId) {
-                memberString += '<input type="checkbox" id="event' + eventObj.id + 'member' 
+        for (j = 0; j<flashTeamsJSON["events"][indexOfJSON].members.length; j++) {
+            if (flashTeamsJSON["events"][indexOfJSON].members[j].uniq === memberUniq) {
+                memberString += '<input type="checkbox" id="event' + memberId + 'member' 
                     + i + 'checkbox" checked="true">' + memberName + "   <br>";
                 found = true;
                 break;
             }
         }
         if (!found) {
-            memberString +=  '<input type="checkbox" id="event' + eventObj.id 
-                + 'member' + i + 'checkbox">' + memberName + "   <br>";
-        }
+            memberString +=  '<input type="checkbox" id="event' + memberId 
+                + 'member' + i + 'checkbox">' + memberName + "   <br>"; 
+        }      
     }
     return memberString;
 };

--- a/foundry/app/assets/javascripts/authoring/popovers.js
+++ b/foundry/app/assets/javascripts/authoring/popovers.js
@@ -246,7 +246,6 @@ var getPopoverDataFromGroupNum = function(groupNum){
 //Called when the user clicks save on an event popover, grabs new info from user and updates 
 //both the info in the popover and the event rectangle graphics
 function saveEventInfo (popId) {
-    console.log("Event saving");
     //Update title
     var newTitle = $("#eventName_" + popId).val();
     if (!newTitle == "") $("#title_text_" + popId).text(newTitle);
@@ -273,16 +272,19 @@ function saveEventInfo (popId) {
     //Update members of event
     flashTeamsJSON["events"][indexOfJSON].members = [];
     for (var i = 0; i<flashTeamsJSON["members"].length; i++) {
+        console.log("checking member", i);
         var member = flashTeamsJSON["members"][i];
         var memberId = member.id;
         var checkbox = $("#event" + popId + "member" + i + "checkbox")[0];
+        //SOMETHING IS WRONG WITH POPID ABOVE
         if (checkbox == undefined) continue;
         if (checkbox.checked == true) {
             console.log("found you", i);
             ev.members.push(memberId); //Update JSON
+        } else {
+            console.log("sorry, didn't find", i);
         }
     }
-    console.log("all the members", ev.members);
 
     //Update width
     var newHours = $("#hours_" + popId).val();
@@ -362,14 +364,14 @@ function writeEventMembers(eventObj) {
         var found = false;
         for (j = 0; j<flashTeamsJSON["events"][indexOfJSON].members.length; j++) {
             if (flashTeamsJSON["events"][indexOfJSON].members[j].uniq === memberUniq) {
-                memberString += '<input type="checkbox" id="event' + memberId + 'member' 
+                memberString += '<input type="checkbox" id="event' + eventObj["id"] + 'member' 
                     + i + 'checkbox" checked="true">' + memberName + "   <br>";
                 found = true;
                 break;
             }
         }
         if (!found) {
-            memberString +=  '<input type="checkbox" id="event' + memberId 
+            memberString +=  '<input type="checkbox" id="event' + eventObj["id"] 
                 + 'member' + i + 'checkbox">' + memberName + "   <br>"; 
         }      
     }

--- a/foundry/app/assets/javascripts/authoring/popovers.js
+++ b/foundry/app/assets/javascripts/authoring/popovers.js
@@ -276,14 +276,10 @@ function saveEventInfo (popId) {
         var member = flashTeamsJSON["members"][i];
         var memberId = member.id;
         var checkbox = $("#event" + popId + "member" + i + "checkbox")[0];
-        //SOMETHING IS WRONG WITH POPID ABOVE
         if (checkbox == undefined) continue;
         if (checkbox.checked == true) {
-            console.log("found you", i);
             ev.members.push(memberId); //Update JSON
-        } else {
-            console.log("sorry, didn't find", i);
-        }
+        } 
     }
 
     //Update width
@@ -306,8 +302,8 @@ function saveEventInfo (popId) {
     ev.x = newX;
     ev.inputs = $('#inputs_' + popId).val();
     ev.outputs = $('#outputs_' + popId).val();
-    console.log(ev.inputs);
 
+    removeAllMemberLines(ev);
     drawEvent(ev, 0);
     drawPopover(ev, true, false);
     

--- a/foundry/app/assets/javascripts/authoring/timeline.js
+++ b/foundry/app/assets/javascripts/authoring/timeline.js
@@ -211,7 +211,7 @@ function addTime() {
     .attr("height", SVG_HEIGHT)
     .attr("fill", "white")
     .attr("fill-opacity", 0)
-    .on("mousedown", addEvent);
+    .on("mousedown", addEvent); //FIX THIS
     
 }
 


### PR DESCRIPTION
TODO #2  - Remove member lines when member is unchecked in popover
Fix: update eventObject, always delete all member lines, and redraw when you saveEventInfo(id)
Note: checkbox checking currently only works (on master and on my branch) when you load a team or reload the page. New events won't keep appropriate boxes checked on the popover. 
