### PR TITLE
AddTime fixed

### DIFF
--- a/foundry/app/assets/javascripts/authoring/events.js
+++ b/foundry/app/assets/javascripts/authoring/events.js
@@ -215,7 +215,7 @@ function createEvent(point) {
 };
 
 function checkWithinTimelineBounds(snapPoint) {
-    return ((snapPoint[1] < 505) && (snapPoint[0] < 2396));
+    return ((snapPoint[1] < 505) && (snapPoint[0] < (SVG_WIDTH-150)));
 };
 
 function getStartTime(mouseX) {

--- a/foundry/app/assets/javascripts/authoring/timeline.js
+++ b/foundry/app/assets/javascripts/authoring/timeline.js
@@ -212,7 +212,6 @@ function addTime() {
     .attr("height", SVG_HEIGHT)
     .attr("fill", "white")
     .attr("fill-opacity", 0)
-    .attr("z-index", -1)
     .on("mousedown", function() {
         var point = d3.mouse(this);
         newEvent(point);

--- a/foundry/app/assets/javascripts/authoring/timeline.js
+++ b/foundry/app/assets/javascripts/authoring/timeline.js
@@ -143,8 +143,9 @@ function addTime() {
     document.getElementById("overlay").style.width = SVG_WIDTH + 50 + "px";
     timeline_svg.attr("width", SVG_WIDTH);
     
-    //Remove all exising grid lines
+    //Remove all existing grid lines & background
     timeline_svg.selectAll("line").remove();
+    timeline_svg.selectAll("rect.background").remove();
     
     //Redraw all x-axis grid lines
     timeline_svg.selectAll("line.x")
@@ -211,7 +212,16 @@ function addTime() {
     .attr("height", SVG_HEIGHT)
     .attr("fill", "white")
     .attr("fill-opacity", 0)
-    .on("mousedown", addEvent); //FIX THIS
+    .attr("z-index", -1)
+    .on("mousedown", function() {
+        var point = d3.mouse(this);
+        newEvent(point);
+    }); 
+
+    //move all existing events back on top of timeline
+    $(timeline_svg.selectAll('g')).each(function() {
+        $('.chart').append(this);
+    });
     
 }
 


### PR DESCRIPTION
Can now draw on both the old and the extended timeline after clicking AddTime. 

ISSUE: extended timeline does not automatically load on refresh. 
FUTURE: want timeline to extend automatically when an event runs over the current timeline? 
