### PR TITLE
Timeline defaults to 48 hours

### DIFF
--- a/foundry/app/assets/javascripts/authoring/timeline.js
+++ b/foundry/app/assets/javascripts/authoring/timeline.js
@@ -3,16 +3,16 @@
  * Code that manages the workflow timeline in Foundry.
  */
 
-var XTicks = 50,
+var XTicks = 100,
     YTicks = 5;
 
-var SVG_WIDTH = 2450,
+var SVG_WIDTH = 4850,
     SVG_HEIGHT = 570;
 
 var STEP_WIDTH = 25,
     HOUR_WIDTH = 100;
 
-var timelineHours = 25;
+var timelineHours = 48;
 var hours = timelineHours*HOUR_WIDTH;
 
 var x = d3.scale.linear()


### PR DESCRIPTION
Changed default timeline editing svg width and xticks. Unable to draw to timeline past 24 hours... likely fixed with previous AddTime bug fix but check! 
