### PR TITLE
Removed popovers on the interaction drawing buttons

### DIFF
--- a/foundry/app/assets/javascripts/authoring/events.js
+++ b/foundry/app/assets/javascripts/authoring/events.js
@@ -519,6 +519,20 @@ function drawHandoffBtn(eventObj, firstTime) {
             .attr("x", function(d) {return d.x+x_offset})
             .attr("y", function(d) {return d.y+y_offset})
             .on("click", startWriteHandoff);
+
+    /*$("#handoff_btn_" + groupNum).popover({
+        trigger: "click",
+        html: true,
+        class: "interactionPopover",
+        style: "font-size: 8px",
+        placement: "right",
+        content: "Click another event to draw a handoff. <br>Click on this event to cancel.",
+        container: $("#timeline-container")
+    });
+    
+    $("#handoff_btn_" + groupNum).popover("show");
+    $("#handoff_btn_" + groupNum).popover("hide");*/
+    
     } else {
         task_g.selectAll(".handoff_btn")
             .attr("x", function(d) {return d.x + x_offset})
@@ -546,6 +560,20 @@ function drawCollabBtn(eventObj, firstTime) {
             .attr("x", function(d) {return d.x+x_offset})
             .attr("y", function(d) {return d.y+y_offset})
             .on("click", startWriteCollaboration);
+
+    /*$("#collab_btn_" + groupNum).popover({
+        trigger: "click",
+        html: true,
+        class: "interactionPopover",
+        style: "font-size: 8px",
+        placement: "right",
+        content: "Click another event to draw a collaboration. <br>Click on this event to cancel.",
+        container: $("#timeline-container")
+    });
+
+    $("#collab_btn_" + groupNum).popover("show");
+    $("#collab_btn_" + groupNum).popover("hide");*/
+    
     } else {
         task_g.selectAll(".collab_btn")
             .attr("x", function(d) {return d.x + x_offset})

--- a/foundry/app/assets/javascripts/authoring/events.js
+++ b/foundry/app/assets/javascripts/authoring/events.js
@@ -519,19 +519,6 @@ function drawHandoffBtn(eventObj, firstTime) {
             .attr("x", function(d) {return d.x+x_offset})
             .attr("y", function(d) {return d.y+y_offset})
             .on("click", startWriteHandoff);
-
-        $("#handoff_btn_" + groupNum).popover({
-            trigger: "click",
-            html: true,
-            class: "interactionPopover",
-            style: "font-size: 8px",
-            placement: "right",
-            content: "Click another event to draw a handoff. <br>Click on this event to cancel.",
-            container: $("#timeline-container")
-        });
-
-        $("#handoff_btn_" + groupNum).popover("show");
-        $("#handoff_btn_" + groupNum).popover("hide");
     } else {
         task_g.selectAll(".handoff_btn")
             .attr("x", function(d) {return d.x + x_offset})
@@ -559,19 +546,6 @@ function drawCollabBtn(eventObj, firstTime) {
             .attr("x", function(d) {return d.x+x_offset})
             .attr("y", function(d) {return d.y+y_offset})
             .on("click", startWriteCollaboration);
-
-        $("#collab_btn_" + groupNum).popover({
-            trigger: "click",
-            html: true,
-            class: "interactionPopover",
-            style: "font-size: 8px",
-            placement: "right",
-            content: "Click another event to draw a collaboration. <br>Click on this event to cancel.",
-            container: $("#timeline-container")
-        });
-
-        $("#collab_btn_" + groupNum).popover("show");
-        $("#collab_btn_" + groupNum).popover("hide");
     } else {
         task_g.selectAll(".collab_btn")
             .attr("x", function(d) {return d.x + x_offset})

--- a/foundry/app/assets/javascripts/authoring/interactions.js
+++ b/foundry/app/assets/javascripts/authoring/interactions.js
@@ -114,9 +114,7 @@ function eventMousedown(task2idNum) {
         }
     //There is no interation being drawn
     } else {
-        console.log("TOGGLING POPOVER");
         var data = getPopoverDataFromGroupNum(task2idNum);
-        console.log("popover content here: " + data.options.content);
         togglePopover(task2idNum);
         return;
     }


### PR DESCRIPTION
The "how to" popovers on the interaction buttons irritated many users in the authoring study and often covered up events they tried to draw handoffs too. Removed - will likely be covered in the upcoming walkthrough mini-project. 
