### PR TITLE
Daniela fixbackground

### DIFF
--- a/foundry/app/assets/javascripts/authoring/sidebar.js
+++ b/foundry/app/assets/javascripts/authoring/sidebar.js
@@ -209,7 +209,8 @@ $(function() {
 //var status_width=302; --> negar's
 /* --------------- PROJECT STATUS BAR START ------------ */
 var project_status_svg = d3.select("#status-bar-container").append("svg")
-.attr("width", SVG_WIDTH)
+/* .attr("width", SVG_WIDTH) */
+.attr("width", 300)
 .attr("height", 100);
 
 var statusText = project_status_svg.append("text").text("You currently have no tasks")

--- a/foundry/app/views/flash_teams/_timeline.html.erb
+++ b/foundry/app/views/flash_teams/_timeline.html.erb
@@ -1,4 +1,4 @@
-<div class="row-fluid" style="width: 2450px;">
+<div class="row-fluid">
 	<div class="span11">
 		<h5 style="padding-bottom: 5px;">TIMELINE</h5>
 	</div>

--- a/foundry/app/views/flash_teams/edit.html.erb
+++ b/foundry/app/views/flash_teams/edit.html.erb
@@ -5,13 +5,12 @@
 
 <%= tag :meta, :name=> 'events_json', :content=> @events_json %>
 
+	<!--Main Layout-->
+	<div class="container-fluid" style="min-width: 1300px; background: #e3e3e3;">
        
 	<% if @in_author_view %>
 	
-	<!--Main Layout-->
-	<div class="container-fluid" style="min-width: 1300px; background: #e3e3e3;">
-    
-     <div class="row-fluid" id="foundry-header" >
+     <div class="row-fluid" id="foundry-header">
 	     <div class="span2 ft-buttons" id="ft-buttons-left">
 			 	<input type="button" class="btn btn-default" id="backBtn" value="Back" onclick="window.location='<%=flash_teams_path%>';"/>
 		  </div>
@@ -94,16 +93,11 @@
 	
 	</div> <!-- end of div class="row-fluid" -->
    
-</div> <!-- end of div class="container-fluid" -->
-
 <% end %> <!--end if in author view conditional--> 
        
     <% if  @in_expert_view %>
-    
-    <!--Main Layout-->
-	<div class="container-fluid" style="min-width: 1300px; background: #e3e3e3;">
-    
-     <div class="row-fluid" id="foundry-header" >   	     
+
+     <div class="row-fluid" id="foundry-header">   	 
 		 <h4 class="text-center">FOUNDRY</h4>  
      </div>
      
@@ -158,10 +152,10 @@
 		</div> <!-- end of body (e.g., class="span9") -->    
 		
 	</div><!-- end of div class="row-fluid" -->
-   
-</div> <!-- end of div class="container-fluid" -->
 
 <% end %> <!--end if in expert view conditional--> 
+
+</div> <!-- end of div class="container-fluid" -->
 
 <%= javascript_include_tag "authoring/gdrive" %>
 <%= javascript_include_tag "application" %>

--- a/foundry/app/views/flash_teams/edit.html.erb
+++ b/foundry/app/views/flash_teams/edit.html.erb
@@ -3,14 +3,13 @@
 <input type="hidden" id="flash_team_name" value="<%= @flash_team.name%>"/>
 <input type="hidden" id="uniq" value=""/>
 
-<div style="background: #e3e3e3;">
 <%= tag :meta, :name=> 'events_json', :content=> @events_json %>
 
        
 	<% if @in_author_view %>
 	
 	<!--Main Layout-->
-	<div class="container-fluid" style="min-width: 1300px">
+	<div class="container-fluid" style="min-width: 1300px; background: #e3e3e3;">
     
      <div class="row-fluid" id="foundry-header" >
 	     <div class="span2 ft-buttons" id="ft-buttons-left">
@@ -102,7 +101,7 @@
     <% if  @in_expert_view %>
     
     <!--Main Layout-->
-	<div class="container-fluid" style="min-width: 1300px">
+	<div class="container-fluid" style="min-width: 1300px; background: #e3e3e3;">
     
      <div class="row-fluid" id="foundry-header" >   	     
 		 <h4 class="text-center">FOUNDRY</h4>  
@@ -163,7 +162,6 @@
 </div> <!-- end of div class="container-fluid" -->
 
 <% end %> <!--end if in expert view conditional--> 
-</div>
 
 <%= javascript_include_tag "authoring/gdrive" %>
 <%= javascript_include_tag "application" %>


### PR DESCRIPTION
I fixed the issue that was preventing the grey background from taking up the entire width on both the author and worker views. 

I also fixed an issue that was causing the width of the page to extend a ton on the worker view. To make this change, I changed the width of the project_status_svg in sidebar.js. Previously it was using SVG_WIDTH which had a width of 4850px. We can change back (I commented it out for now) if needed but this was problematic. 

/\* --------------- PROJECT STATUS BAR START ------------ _/
var project_status_svg = d3.select("#status-bar-container").append("svg")
/_ .attr("width", SVG_WIDTH) */
.attr("width", 300)
