### PR TITLE
updated the chat status text

### DIFF
--- a/foundry/app/assets/javascripts/authoring/sidebar.js
+++ b/foundry/app/assets/javascripts/authoring/sidebar.js
@@ -57,19 +57,19 @@ function displayChatMessage(name, uniq, role, date, text) {
     //notification body
     var notif_body = dateform;
     
-    var showchat; // true if notifications should be shown
+    var showchatnotif; // true if notifications should be shown
         
     if ((current_user == 'Author' && role == 'Author') || (current_user.uniq == uniq)){
-    	showchat = false;
+    	showchatnotif = false;
     }
     else{
-	    showchat = true;
+	    showchatnotif = true;
     }
     
     // checks if last notification was less than 5 seconds ago
     // this is used to only create notifications for messages that were sent from the time you logged in and forward 
     // (e.g., no notifications for messages in the past)
-    if (diff <= 50000 && showchat == true){
+    if (diff <= 50000 && showchatnotif == true){
 	    notifyMe(notif_title, notif_body, 'chat');
     }
 
@@ -124,7 +124,7 @@ connectedRef.on('value', function(snap) {
 		myUserRef.onDisconnect().remove();
 
 		// Set our initial online status.
-		setUserStatus("★ online");
+		setUserStatus("online ★");
       
     } else {
 
@@ -155,7 +155,7 @@ userListRef.on("child_added", function(snapshot) {
 	
 	$("<div/>")
 	  .attr("id", getMessageId(snapshot))
-	  .text(user.name + " is currently " + user.status)
+	  .text(user.name + " is " + user.status)
 	  .appendTo("#presenceDiv");
 });
 
@@ -169,28 +169,31 @@ userListRef.on("child_removed", function(snapshot) {
 userListRef.on("child_changed", function(snapshot) {
 	var user = snapshot.val();
 	$("#presenceDiv").children("#" + getMessageId(snapshot))
-	  .text(user.name + " is currently " + user.status);
+	  .text(user.name + " is " + user.status);
 });
   
 
 // Use idle/away/back events created by idle.js to update our status information.
 $(function() { 
 
+	// when user is inactive for 60 seconds
 	var awayCallback = function() {
-		setUserStatus("☄ away");
+		setUserStatus("away");
 	};
 	
 	var awayBackCallback = function() {
-		setUserStatus("★ online");
+		setUserStatus("online ★");
 	};
 	
+	//when user is looking at another tab
 	var hiddenCallback = function() {
 		//☆ idle
-		setUserStatus("not looking at page");
+		setUserStatus("idle ☆");
 	};
 	
 	var visibleCallback = function(){
-		setUserStatus("looking at page again")
+		//setUserStatus("active again");
+		setUserStatus("online ★");
 	};
 
 	var idle = new Idle({


### PR DESCRIPTION
Updated the presence information (e.g., user status) in the chat so that the user's status: 
-- changes to idle when user is looking at another tab
-- changes to away when user is inactive for 60 seconds
-- no longer includes the weird away icon
-- added an unfilled star to the idle status
-- moved the star icons so it shows up after the text

To-dos remaining include (will file issues for these): 
-- Showing offline users (with status set to "offline")
-- When user has page open on multiple tabs or devices, user should only appear once on list and presence info should be based off the most recent activity 
