### PR TITLE
AT Total Hours Fix

### DIFF
--- a/foundry/app/assets/javascripts/authoring/awareness.js
+++ b/foundry/app/assets/javascripts/authoring/awareness.js
@@ -125,6 +125,7 @@ var currentStatus; //the status of the user shown in the presence box
 
 $(document).ready(function(){
     colorBox();
+    
     var flash_team_id = $("#flash_team_id").val();
     var url = '/flash_teams/' + flash_team_id + '/get_status';
     $.ajax({
@@ -144,6 +145,7 @@ $(document).ready(function(){
         flashTeamsJSON = loadedStatus.flash_teams_json;
 
         setCurrentMember();
+        initializeTimelineDuration();
 
         if(in_progress){
             //console.log("flash team in progress");

--- a/foundry/app/assets/javascripts/authoring/helper.js
+++ b/foundry/app/assets/javascripts/authoring/helper.js
@@ -9,8 +9,7 @@ var flashTeamsJSON = {
     "id" : 1,
     "events": [],        //{"title", "id", "startTime", "duration", "notes", "members": [], "dri", "yPosition", inputs”:[], “outputs”:[]}
     "members": [],       //{"id", "role", "skills":[], "color", "category1", "category2"}
-    "interactions" : [],  //{"event1", "event2", "type", "description", "id"}
-    "TOTAL_HOURS": 48
+    "interactions" : []  //{"event1", "event2", "type", "description", "id"}
 };
 
 function pressEnterKeyToSubmit(inputId, buttonId) {

--- a/foundry/app/assets/javascripts/authoring/helper.js
+++ b/foundry/app/assets/javascripts/authoring/helper.js
@@ -22,7 +22,7 @@ function pressEnterKeyToSubmit(inputId, buttonId) {
 	});
 }
 
-//FOR TESTING, DELETE LATER
+/*//FOR TESTING, DELETE LATER
 fakeJSON = {
 	"title" : "New Flash Team",
     "id" : 1,
@@ -34,10 +34,10 @@ fakeJSON = {
     "members": [{"id":1, "role":"Illustrator", "category1":"Web Development", "category2":"UI Design", "skills":["shopify"], "color":"BLUE"}, 
     	{"id":2, "role":"Author", "category1":"Writing & Translation", "category2":"Creative Writing", "skills":["ebooks"], "color":"RED"}],       
     "interactions" : []  //{"event1", "event2", "type", "description"}       
-};
+};*/
 
 
-//Takes a Flash Teams JSON Object and Draws a Flash Team
+/*//Takes a Flash Teams JSON Object and Draws a Flash Team
 function drawFlashTeamFromJSON(ftJSON) {
     //Populate members
     //console.log("ftJSON: ");
@@ -93,6 +93,22 @@ function drawFlashTeamFromJSON(ftJSON) {
     }
     
     //DRAW INTERACTIONS
+}*/
+
+//Find the total hours (duration) of the entire team
+function findTotalHours() {
+    var totalHours = 48; 
+    for (i = 0; i < flashTeamsJSON["events"].length; i++) {
+        var eventObj = flashTeamsJSON["events"][i];
+        var eventStart = eventObj.startTime;
+        var eventDuration = eventObj.duration;
+        var eventEnd = eventStart + eventDuration;
+        var hours = (eventEnd - (eventEnd%60))/60; 
+        if (hours > totalHours) totalHours = hours;
+    }
+    //NOTE: the above cut off minutes past the hour, must add at least 1 extra hour to return val
+    totalHours++; 
+    return totalHours + 2; //THE 2 IS ARBITRARY FOR PADDING
 }
 
 //CALL IN CONSOLE TO HIDE THE CHAT BOX AND PROJECT STATUS

--- a/foundry/app/assets/javascripts/authoring/helper.js
+++ b/foundry/app/assets/javascripts/authoring/helper.js
@@ -9,7 +9,8 @@ var flashTeamsJSON = {
     "id" : 1,
     "events": [],        //{"title", "id", "startTime", "duration", "notes", "members": [], "dri", "yPosition", inputs”:[], “outputs”:[]}
     "members": [],       //{"id", "role", "skills":[], "color", "category1", "category2"}
-    "interactions" : []  //{"event1", "event2", "type", "description", "id"}
+    "interactions" : [],  //{"event1", "event2", "type", "description", "id"}
+    "TOTAL_HOURS": 48
 };
 
 function pressEnterKeyToSubmit(inputId, buttonId) {

--- a/foundry/app/assets/javascripts/authoring/timeline.js
+++ b/foundry/app/assets/javascripts/authoring/timeline.js
@@ -97,7 +97,20 @@ timeline_svg.append("line")
     .attr("y1", 15)
     .attr("y2", SVG_HEIGHT-50)
     .style("stroke", "#000")
-    .style("stroke-width", "4")
+    .style("stroke-width", "4");
+
+//Extend the timeline the necessary amount for the project
+function initializeTimelineDuration() {
+    var totalHours = findTotalHours();
+    if (totalHours > 48) {
+        TIMELINE_HOURS = totalHours;
+        TOTAL_HOUR_PIXELS = TIMELINE_HOURS * HOUR_WIDTH;
+        SVG_WIDTH = TIMELINE_HOURS * 100 + 50;
+        XTicks = TIMELINE_HOURS * 2;
+        redrawTimeline();
+    }
+}
+
 
 var task_g = timeline_svg.selectAll(".task_g");
 
@@ -127,29 +140,14 @@ function getEventJSONIndex(idNum) {
     }
 };
 
-//Find the total hours (duration) of the entire team
-function findTotalHours() {
-    var totalHours = 48; 
-    for (i = 0; i < flashTeamsJSON["events"].length; i++) {
-        var eventObj = flashTeamsJSON["events"][i];
-        var eventStart = eventObj.startTime;
-        var eventDuration = eventObj.duration;
-        var eventEnd = eventStart + eventDuration;
-        var hours = (eventEnd - (eventEnd%60))/60; 
-        if (hours > totalHours) totalHours = hours;
-    }
-    //NOTE: the above cut off minutes past the hour, must add at least 1 extra hour to return val
-    totalHours++; 
-    return totalHours + 2; //THE 2 IS ARBITRARY FOR PADDING
-}
-
-
 //VCom Time expansion button trial 
 function addTime() {
     calcAddHours(TIMELINE_HOURS);
     redrawTimeline();
 }
 
+//Should have updated the variables: TIMELINE_HOURS, TOTAL_HOUR_PIXELS, SVG_WIDTH, XTicks
+//Redraws timeline based on those numbers
 function redrawTimeline() {
     //Recalculate 'x' based on added hours
     var x = d3.scale.linear()
@@ -247,7 +245,6 @@ function redrawTimeline() {
 function calcAddHours(currentHours) {
     TIMELINE_HOURS = currentHours + Math.floor(currentHours/3);
     TOTAL_HOUR_PIXELS = TIMELINE_HOURS * HOUR_WIDTH;
-    
     SVG_WIDTH = TIMELINE_HOURS * 100 + 50;
     XTicks = TIMELINE_HOURS * 2;
 }

--- a/foundry/app/assets/javascripts/authoring/timeline.js
+++ b/foundry/app/assets/javascripts/authoring/timeline.js
@@ -103,12 +103,6 @@ var task_g = timeline_svg.selectAll(".task_g");
 
 //Set the width of the timeline header row so add time button is all the way to the right
 document.getElementById("timeline-header").style.width = SVG_WIDTH - 50 + "px";
-    
-//OLD CODE: Stop following the position of the mouse
-/*function handoffMouseClick() {
-    //SET INDICATOR TO FALSE, WHEN CLICKED ANYWHERE
-    timeline_svg.on("mousemove", null);
-}*/
 
 //Turn on the overlay so a user cannot continue to draw events when focus is on a popover
 function overlayOn() {
@@ -132,6 +126,23 @@ function getEventJSONIndex(idNum) {
         }
     }
 };
+
+//Find the total hours (duration) of the entire team
+function findTotalHours() {
+    var totalHours = 48; 
+    for (i = 0; i < flashTeamsJSON["events"].length; i++) {
+        var eventObj = flashTeamsJSON["events"][i];
+        var eventStart = eventObj.startTime;
+        var eventDuration = eventObj.duration;
+        var eventEnd = eventStart + eventDuration;
+        var hours = (eventEnd - (eventEnd%60))/60; 
+        if (hours > totalHours) totalHours = hours;
+    }
+    //NOTE: the above cut off minutes past the hour, must add at least 1 extra hour to return val
+    totalHours++; 
+
+    return totalHours; //THE 4 IS ARBITRARY FOR PADDING
+}
 
 //VCom Time expansion button trial 
 function addTime() {
@@ -231,7 +242,7 @@ function addTime() {
     
 }
 
-//VCom Calculates how many hours to add when user expands timeline
+//VCom Calculates how many hours to add when user expands timeline manually 
 function calcAddHours(currentHours) {
     timelineHours = currentHours + Math.floor(currentHours/3);
     hours = timelineHours * HOUR_WIDTH;

--- a/foundry/app/assets/javascripts/authoring/timeline.js
+++ b/foundry/app/assets/javascripts/authoring/timeline.js
@@ -12,12 +12,12 @@ var SVG_WIDTH = 4850,
 var STEP_WIDTH = 25,
     HOUR_WIDTH = 100;
 
-var timelineHours = 48;
-var hours = timelineHours*HOUR_WIDTH;
+var TIMELINE_HOURS = 48;
+var TOTAL_HOUR_PIXELS = TIMELINE_HOURS*HOUR_WIDTH;
 
 var x = d3.scale.linear()
-    .domain([0, hours])
-    .range([0, hours]);
+    .domain([0, TOTAL_HOUR_PIXELS])
+    .range([0, TOTAL_HOUR_PIXELS]);
 
 var y = d3.scale.linear() 
     .domain([15, 600])
@@ -140,18 +140,21 @@ function findTotalHours() {
     }
     //NOTE: the above cut off minutes past the hour, must add at least 1 extra hour to return val
     totalHours++; 
-
-    return totalHours; //THE 4 IS ARBITRARY FOR PADDING
+    return totalHours + 2; //THE 2 IS ARBITRARY FOR PADDING
 }
+
 
 //VCom Time expansion button trial 
 function addTime() {
-    calcAddHours(timelineHours);
-    
+    calcAddHours(TIMELINE_HOURS);
+    redrawTimeline();
+}
+
+function redrawTimeline() {
     //Recalculate 'x' based on added hours
     var x = d3.scale.linear()
-    .domain([0, hours])
-    .range([0, hours]);
+    .domain([0, TOTAL_HOUR_PIXELS])
+    .range([0, TOTAL_HOUR_PIXELS]);
     
     //Reset overlay and svg width
     document.getElementById("overlay").style.width = SVG_WIDTH + 50 + "px";
@@ -163,44 +166,43 @@ function addTime() {
     
     //Redraw all x-axis grid lines
     timeline_svg.selectAll("line.x")
-    .data(x.ticks(XTicks)) 
-    .enter().append("line")
-    .attr("class", "x")
-    .attr("x1", x)
-    .attr("x2", x)
-    .attr("y1", 15)
-    .attr("y2", SVG_HEIGHT-50)
-    .style("stroke", "rgba(100, 100, 100, .5)");
+        .data(x.ticks(XTicks)) 
+        .enter().append("line")
+        .attr("class", "x")
+        .attr("x1", x)
+        .attr("x2", x)
+        .attr("y1", 15)
+        .attr("y2", SVG_HEIGHT-50)
+        .style("stroke", "rgba(100, 100, 100, .5)");
     
     //Redraw all y-axis grid lines
     timeline_svg.selectAll("line.y")
-    .data(yLines) 
-    .enter().append("line")
-    .attr("class", "y")
-    .attr("x1", 0)
-    .attr("x2", SVG_WIDTH-50)
-    .attr("y1", y)
-    .attr("y2", y)
-    .style("stroke", "#d3d1d1");
+        .data(yLines) 
+        .enter().append("line")
+        .attr("class", "y")
+        .attr("x1", 0)
+        .attr("x2", SVG_WIDTH-50)
+        .attr("y1", y)
+        .attr("y2", y)
+        .style("stroke", "#d3d1d1");
     
     //Redraw darker first x and y grid lines
     timeline_svg.append("line")
-    .attr("x1", 0)
-    .attr("x2", SVG_WIDTH-50)
-    .attr("y1", 15)
-    .attr("y2", 15)
-    .style("stroke", "#000")
-    .style("stroke-width", "4")
+        .attr("x1", 0)
+        .attr("x2", SVG_WIDTH-50)
+        .attr("y1", 15)
+        .attr("y2", 15)
+        .style("stroke", "#000")
+        .style("stroke-width", "4");
     
     timeline_svg.append("line")
-    .attr("y1", 15)
-    .attr("y2", SVG_HEIGHT-50)
-    .style("stroke", "#000")
-    .style("stroke-width", "4")
+        .attr("y1", 15)
+        .attr("y2", SVG_HEIGHT-50)
+        .style("stroke", "#000")
+        .style("stroke-width", "4");
     
     //Redraw Add Time Button
     document.getElementById("timeline-header").style.width = SVG_WIDTH - 50 + "px";
-    
     
     //Remove existing X-axis labels -- can't get this to work
     //timeline_svg.selectAll(".rule").remove();
@@ -208,45 +210,44 @@ function addTime() {
 
     //Redraw X-axis labels
     timeline_svg.selectAll(".rule")
-    .data(x.ticks(XTicks))
-    .enter().append("text")
-    .attr("x", x)
-    .attr("y", 15)
-    .attr("dy", -3)
-    .attr("text-anchor", "middle")
-    .text(function(d) {
-        numMins+= 30;
-        var hours = Math.floor(numMins/60);
-        var minutes = numMins%60;
-        if (minutes == 0 && hours == 0) return ".     .      .    .    0:00";
-        else if (minutes == 0) return hours + ":00";
-        else return hours + ":" + minutes; 
-    });
+        .data(x.ticks(XTicks))
+        .enter().append("text")
+        .attr("x", x)
+        .attr("y", 15)
+        .attr("dy", -3)
+        .attr("text-anchor", "middle")
+        .text(function(d) {
+            numMins+= 30;
+            var hours = Math.floor(numMins/60);
+            var minutes = numMins%60;
+            if (minutes == 0 && hours == 0) return ".     .      .    .    0:00";
+            else if (minutes == 0) return hours + ":00";
+            else return hours + ":" + minutes; 
+        });
     
     //Add ability to draw rectangles on extended timeline
     timeline_svg.append("rect")
-    .attr("class", "background")
-    .attr("width", SVG_WIDTH)
-    .attr("height", SVG_HEIGHT)
-    .attr("fill", "white")
-    .attr("fill-opacity", 0)
-    .on("mousedown", function() {
-        var point = d3.mouse(this);
-        newEvent(point);
-    }); 
+        .attr("class", "background")
+        .attr("width", SVG_WIDTH)
+        .attr("height", SVG_HEIGHT)
+        .attr("fill", "white")
+        .attr("fill-opacity", 0)
+        .on("mousedown", function() {
+            var point = d3.mouse(this);
+            newEvent(point);
+        }); 
 
     //move all existing events back on top of timeline
     $(timeline_svg.selectAll('g')).each(function() {
         $('.chart').append(this);
     });
-    
 }
 
 //VCom Calculates how many hours to add when user expands timeline manually 
 function calcAddHours(currentHours) {
-    timelineHours = currentHours + Math.floor(currentHours/3);
-    hours = timelineHours * HOUR_WIDTH;
+    TIMELINE_HOURS = currentHours + Math.floor(currentHours/3);
+    TOTAL_HOUR_PIXELS = TIMELINE_HOURS * HOUR_WIDTH;
     
-    SVG_WIDTH = timelineHours * 100 + 50;
-    XTicks = timelineHours * 2;
+    SVG_WIDTH = TIMELINE_HOURS * 100 + 50;
+    XTicks = TIMELINE_HOURS * 2;
 }


### PR DESCRIPTION
Timeline defaults to 48 hours on new and old teams. 

Checks over all events in the JSON, if an event ends later than 48 hours, loop over and find the last-ending event. Calculate total hours and update timeline as necessary. (currently rounds up by an hour and arbitrarily adds 2 for padding). 

Want to check that timeline defaults correctly on author and worker mode. 
