### PR TITLE
Replacing members both in run time and static modes. Also fixed a bug that prevented members from showing up in run time.

### DIFF
--- a/foundry/app/assets/javascripts/authoring/awareness.js
+++ b/foundry/app/assets/javascripts/authoring/awareness.js
@@ -153,7 +153,13 @@ $(document).ready(function(){
 			$("#flashTeamStartBtn").css('display','none'); //not sure if this is necessary since it's above 
 			$("#flashTeamEndBtn").css('display',''); //not sure if this is necessary since it's above 
             loadData(true);
-            renderMembersUser();
+             if(!isUser) {
+                    renderMembersRequester();
+                }
+             else{
+                    renderMembersUser();
+                }
+
             startTeam(true);
         } else {
             //console.log("flash team not in progress");
@@ -1111,6 +1117,7 @@ var updateStatus = function(flash_team_in_progress){
     if(flash_team_in_progress != undefined){ // could be undefined if want to call updateStatus in a place where not sure if the team is running or not
         localStatus.flash_team_in_progress = flash_team_in_progress;
     } else {
+      //  alert(in_progress);
         localStatus.flash_team_in_progress = in_progress;
     }
     localStatus.latest_time = (new Date).getTime();

--- a/foundry/app/assets/javascripts/authoring/members.js
+++ b/foundry/app/assets/javascripts/authoring/members.js
@@ -152,8 +152,9 @@ function renderMemberPopovers(members) {
         content +='</ul>'
         +'Member Color: <input type="text" class="full-spectrum" id="color_' + member_id + '"/>'
         +'<p><script type="text/javascript"> initializeColorPicker(' + newColor +'); </script></p>'
-        +'<p><button class="btn btn-danger" type="button" onclick="deleteMember(' + member_id + ');">Delete</button>     '
-        +'<button class="btn btn-success" type="button" onclick="saveMemberInfo(' + member_id + '); updateStatus();">Save</button>     '
+        +'<p><button class="btn btn-default" type="button" onclick="deleteMember(' + member_id + ');">Delete</button>     '
+        +'<button class="btn btn-default" type="button" onclick="saveMemberInfo(' + member_id + '); updateStatus();">Save</button>     '
+        +'<button class="btn btn-default" type="button" onclick="reInviteMember(' + member_id + '); updateStatus();">Replace</button>     '
         +'<button class="btn btn-default" type="button" onclick="hideMemberPopover(' + member_id + ');">Cancel</button><br><br>'
         + 'Invitation link: <a id="invitation_link_' + member_id + '" href="' + invitation_link + '" target="_blank">'
         + invitation_link
@@ -379,6 +380,29 @@ function inviteMember(pillId) {
         var members = flashTeamsJSON["members"];
         members[indexOfJSON].uniq = data["uniq"];
         members[indexOfJSON].invitation_link = data["url"];
+
+        renderMemberPopovers(members);
+        updateStatus(false);
+    });
+};
+
+function reInviteMember(pillId) {
+
+    var flash_team_id = $("#flash_team_id").val();
+    var url = '/members/' + flash_team_id + '/reInvite';
+    var indexOfJSON = getMemberJSONIndex(pillId);
+    var uniq;
+    var data = {uniq: flashTeamsJSON["members"][indexOfJSON].uniq };
+    $.get(url, data, function(data){
+        //console.log("INVITED MEMBER, NOT RERENDERING MEMBER POPOVER");
+        var members = flashTeamsJSON["members"];
+        members[indexOfJSON].uniq = data["uniq"];
+        members[indexOfJSON].invitation_link = data["url"];
+        //members[indexOfJSON].category1 = "";
+        //members[indexOfJSON].category2 = "";
+        //members[indexOfJSON].skills = [];
+
+
 
         renderMemberPopovers(members);
         updateStatus(false);

--- a/foundry/app/assets/javascripts/authoring/members.js
+++ b/foundry/app/assets/javascripts/authoring/members.js
@@ -405,7 +405,7 @@ function reInviteMember(pillId) {
 
 
         renderMemberPopovers(members);
-        updateStatus(false);
+        //updateStatus(false);
     });
 };
 

--- a/foundry/app/controllers/flash_teams_controller.rb
+++ b/foundry/app/controllers/flash_teams_controller.rb
@@ -36,6 +36,10 @@ class FlashTeamsController < ApplicationController
     @flash_teams = FlashTeam.all.order(:id).reverse_order
   end
 
+rescue_from ActiveRecord::RecordNotFound do
+  #flash[:notice] = 'The object you tried to access does not exist'
+  render 'member_doesnt_exist'   # or e.g. redirect_to :action => :index
+end
  
   def edit
     @flash_team = FlashTeam.find(params[:id])
@@ -58,6 +62,12 @@ class FlashTeamsController < ApplicationController
      @in_author_view = false
 
      uniq = params[:uniq]
+    
+     Member.find_by! uniq: uniq
+     #if !(Member.exist(:uniq => uniq))  #role has been reinvited and doesn't exist anymore
+     #   render 'member_doesnt_exist'
+     #end 
+
      member = Member.where(:uniq => uniq)[0]
      @user_name = member.name
 

--- a/foundry/app/controllers/members_controller.rb
+++ b/foundry/app/controllers/members_controller.rb
@@ -2,10 +2,38 @@ require 'json'
 
 class MembersController < ApplicationController
   def invite
+
     uniq = params[:uniq]
     if !uniq
       uniq = SecureRandom.uuid
     end
+
+    # generate unique id and add to url below
+    url = url_for :action => 'invited', :id => params[:id], :uniq => uniq
+    
+    #UserMailer.send_email(email, url).deliver
+
+    respond_to do |format|
+      format.json {render json: {:url => url, :uniq => uniq}.to_json, status: :ok}
+    end
+  end
+
+  def reInvite
+
+    prev_uniq = params[:uniq]
+    
+
+    uniq = SecureRandom.uuid
+    
+
+    member = Member.where(:uniq => prev_uniq)[0]
+    member.name = nil
+    member.color = nil
+    member.email = nil
+    member.confirm_email_uniq = nil
+    member.email_confirmed = nil
+    member.uniq = nil
+    member.save
 
     # generate unique id and add to url below
     url = url_for :action => 'invited', :id => params[:id], :uniq => uniq

--- a/foundry/app/views/flash_teams/member_doesnt_exist.html.erb
+++ b/foundry/app/views/flash_teams/member_doesnt_exist.html.erb
@@ -1,0 +1,1 @@
+Your link to Foundry is not active any more. Please contact the author if your link has been deactivated by mistake.

--- a/foundry/config/routes.rb
+++ b/foundry/config/routes.rb
@@ -83,6 +83,7 @@ Foundry::Application.routes.draw do
   resources :members do
     member do
       get :invite
+      get :reInvite
       get :invited
       get :confirm_email
       post :register


### PR DESCRIPTION
- Added a replace button to members popover.
- Clicking on the replace button resets the invitation link and deactivates the previous user's unique link to Foundry.
- This feature should be tested both in run time mode and static modes.

-Also, the members should show up on author's page in run time even after the page is reloaded. 
