### PR TITLE
Redraw Cursor on Timeline Redraw

### DIFF
--- a/foundry/app/assets/javascripts/authoring/awareness.js
+++ b/foundry/app/assets/javascripts/authoring/awareness.js
@@ -22,7 +22,7 @@ var fire_interval = 180; // change back to 180
 var numIntervals = parseFloat(timeline_interval)/parseFloat(fire_interval);
 var increment = parseFloat(50)/parseFloat(numIntervals);
 var curr_x_standard = 0;
-var cursor = timeline_svg.select(".cursor");
+var cursor = timeline_svg.select(".cursor"); //Refers to the physical cursor
 var live_tasks = [];
 var remaining_tasks = [];
 var delayed_tasks = [];
@@ -34,13 +34,14 @@ var in_progress = false;
 var delayed_tasks_time = [];
 var dri_responded = [];
 var project_status_handler;
-var cursor_details;
+var cursor_details; //Stores the cursor's x position "finalX" and ? "numInt"
 var cursor_interval_id;
 var tracking_tasks_interval_id;
 
 var window_visibility_state = null;
 var window_visibility_change = null;
 
+//Takes time as input, finds the x coordinate for the cursor
 var getXCoordForTime = function(t){
     var numInt = parseInt(t / timeline_interval);
     var remainder = t % timeline_interval;
@@ -549,23 +550,22 @@ var computeTotalOffset = function(allRanges){
     return totalOffset;
 };
 
+//Takes the JSON and time and updates the cursor position
 var positionCursor = function(team, latest_time){
+    //Team hasn't started, initialize cursor to 0
     if(!team["startTime"]){
         cursor.attr("x1", 0);
         cursor.attr("x2", 0);
         curr_x_standard = 0;
         return;
     }
-
     var currTime = latest_time;
     var startTime = team["startTime"];
     var diff = currTime - startTime;
 
-    //console.log(startTime);
-    //console.log(currTime);
-    //console.log("diff in seconds: " + diff/1000);
-
     var cursor_details = getXCoordForTime(diff);
+
+    //Update x coordinate of the cursor
     var x = cursor_details["finalX"];
     cursor.attr("x1", x);
     cursor.attr("x2", x);

--- a/foundry/app/assets/javascripts/authoring/awareness.js
+++ b/foundry/app/assets/javascripts/authoring/awareness.js
@@ -283,7 +283,7 @@ var flashTeamUpdated = function(){
 var poll = function(){
     //console.log("POLLING");
     return setInterval(function(){
-        console.log("MAKING POLL NOW...");
+        //console.log("MAKING POLL NOW...");
         var flash_team_id = $("#flash_team_id").val();
         var url = '/flash_teams/' + flash_team_id + '/get_status';
         $.ajax({
@@ -319,8 +319,6 @@ var loadStatus = function(id){
         loadedStatusJSON = data;
         //console.log("loadedStatusJSON: " + loadedStatusJSON);
     });
- 
-    
     return JSON.parse(loadedStatusJSON);
 };
 

--- a/foundry/app/assets/javascripts/authoring/sidebar.js
+++ b/foundry/app/assets/javascripts/authoring/sidebar.js
@@ -9,7 +9,7 @@ var name;
 
 $('#messageInput').keydown(function(e){
     if (e.keyCode == 13) {
-        console.log("PRESSED RETURN KEY!");
+        //console.log("PRESSED RETURN KEY!");
         var text = $('#messageInput').val();
         var uniq_u=getParameterByName('uniq');
         
@@ -24,9 +24,9 @@ $('#messageInput').keydown(function(e){
 
 myDataRef.on('child_added', function(snapshot) {
     var message = snapshot.val();
-    console.log(snapshot);
-    console.log(message);
-    console.log("MESSAGE NAME: " + message["name"]);
+    //console.log(snapshot);
+    //console.log(message);
+    //console.log("MESSAGE NAME: " + message["name"]);
 
     displayChatMessage(message.name, message.uniq, message.role, message.date, message.text);
     
@@ -49,7 +49,7 @@ function displayChatMessage(name, uniq, role, date, text) {
     var diff = Math.abs(new Date() - message_date);
     
     //diff in minutes
-    console.log("minutes ago: " + diff/(1000*60)); 
+    //console.log("minutes ago: " + diff/(1000*60)); 
     
     //notification text   
     //notification title
@@ -332,9 +332,9 @@ function init_statusBar(status_bar_timeline_interval){
         
     }
    // last_end_x=parseFloat(last_end_x)/50*thirty_min; //TODO change to width
-   console.log("last_end",last_end_x);
+   //console.log("last_end",last_end_x);
    project_duration=parseInt(last_end_x/50)*thirty_min;
-   console.log("project duration: ",project_duration);
+   //console.log("project duration: ",project_duration);
 
    num_intervals=(parseFloat(project_duration)/parseFloat(status_bar_timeline_interval));
    project_status_interval_width=parseFloat(status_width)/parseFloat(num_intervals);
@@ -388,10 +388,10 @@ function load_statusBar(status_bar_timeline_interval){
         
 
         // last_end_x=parseFloat(last_end_x)/50*thirty_min; //TODO change to width
-        console.log("last_end",last_end_x);
+        //console.log("last_end",last_end_x);
         var cursor_x = cursor.attr("x1");
         project_duration=parseInt((last_end_x)/50)*thirty_min;
-        console.log("project duration: ",project_duration);
+        //console.log("project duration: ",project_duration);
 
         num_intervals=(parseFloat(project_duration)/parseFloat(status_bar_timeline_interval));
         project_status_interval_width=parseFloat(status_width)/parseFloat(num_intervals);
@@ -436,9 +436,9 @@ function load_statusBar(status_bar_timeline_interval){
     }
 
    // last_end_x=parseFloat(last_end_x)/50*thirty_min; //TODO change to width
-   console.log("last_end",last_end_x);
+   //console.log("last_end",last_end_x);
    project_duration=parseInt(last_end_x/50)*thirty_min;
-   console.log("project duration: ",project_duration);
+   //console.log("project duration: ",project_duration);
 
    num_intervals=(parseFloat(project_duration)/parseFloat(status_bar_timeline_interval));
    project_status_interval_width=parseFloat(status_width)/parseFloat(num_intervals);

--- a/foundry/app/assets/javascripts/authoring/timeline.js
+++ b/foundry/app/assets/javascripts/authoring/timeline.js
@@ -151,6 +151,7 @@ function addTime() {
 //Should have updated the variables: TIMELINE_HOURS, TOTAL_HOUR_PIXELS, SVG_WIDTH, XTicks
 //Redraws timeline based on those numbers
 function redrawTimeline() {
+    //debugger;
     //Recalculate 'x' based on added hours
     var x = d3.scale.linear()
     .domain([0, TOTAL_HOUR_PIXELS])
@@ -238,10 +239,23 @@ function redrawTimeline() {
             newEvent(point);
         }); 
 
+     //START HERE
+    /* Time cursor in red */
+    timeline_svg.append("line")
+        .attr("y1", 15)
+        .attr("y2", SVG_HEIGHT-50)
+        .attr("x1", 0)
+        .attr("x2", 0)
+        .attr("class", "cursor")
+        .style("stroke", "red")
+        .style("stroke-width", "2")
+
     //move all existing events back on top of timeline
     $(timeline_svg.selectAll('g')).each(function() {
         $('.chart').append(this);
     });
+   
+
 }
 
 //VCom Calculates how many hours to add when user expands timeline manually 

--- a/foundry/app/assets/javascripts/authoring/timeline.js
+++ b/foundry/app/assets/javascripts/authoring/timeline.js
@@ -239,8 +239,7 @@ function redrawTimeline() {
             newEvent(point);
         }); 
 
-     //START HERE
-    /* Time cursor in red */
+    //Redraw the cursor
     timeline_svg.append("line")
         .attr("y1", 15)
         .attr("y2", SVG_HEIGHT-50)
@@ -250,6 +249,7 @@ function redrawTimeline() {
         .style("stroke", "red")
         .style("stroke-width", "2")
 
+    //Get the latest time and team status, update x position of cursor
     var latest_time;
     if (in_progress){
         latest_time = (new Date).getTime();
@@ -257,8 +257,9 @@ function redrawTimeline() {
         latest_time = loadedStatus.latest_time;
     }
     cursor_details = positionCursor(flashTeamsJSON, latest_time);
-    //loadData(in_progress);
 
+    //TODO: REMOVE
+    //Debugging the cursor redrawing
     cursorDebug();
     function cursorDebug() {
         console.log("CURSOR DEBUG INFO!!!!!");

--- a/foundry/app/assets/javascripts/authoring/timeline.js
+++ b/foundry/app/assets/javascripts/authoring/timeline.js
@@ -66,12 +66,14 @@ timeline_svg.selectAll("line.y")
     .attr("y2", y)
     .style("stroke", "#d3d1d1");
 
+//Remove existing X-axis labels
 var numMins = -30;
 
 //Add X Axis Labels
-timeline_svg.selectAll(".rule")
+timeline_svg.selectAll("text.timelabel")
     .data(x.ticks(XTicks)) 
     .enter().append("text")
+    .attr("class", "timelabel")
     .attr("x", x)
     .attr("y", 15)
     .attr("dy", -3)
@@ -202,14 +204,15 @@ function redrawTimeline() {
     //Redraw Add Time Button
     document.getElementById("timeline-header").style.width = SVG_WIDTH - 50 + "px";
     
-    //Remove existing X-axis labels -- can't get this to work
-    //timeline_svg.selectAll(".rule").remove();
+    //Remove existing X-axis labels
+    timeline_svg.selectAll("text.timelabel").remove();
     numMins = -30;
 
     //Redraw X-axis labels
-    timeline_svg.selectAll(".rule")
+    timeline_svg.selectAll("text.timelabel")
         .data(x.ticks(XTicks))
         .enter().append("text")
+        .attr("class", "timelabel")
         .attr("x", x)
         .attr("y", 15)
         .attr("dy", -3)
@@ -242,9 +245,10 @@ function redrawTimeline() {
 }
 
 //VCom Calculates how many hours to add when user expands timeline manually 
+//Increases by 1/3 each time (130% original length)
 function calcAddHours(currentHours) {
     TIMELINE_HOURS = currentHours + Math.floor(currentHours/3);
     TOTAL_HOUR_PIXELS = TIMELINE_HOURS * HOUR_WIDTH;
-    SVG_WIDTH = TIMELINE_HOURS * 100 + 50;
+    SVG_WIDTH = TIMELINE_HOURS * HOUR_WIDTH + 50;
     XTicks = TIMELINE_HOURS * 2;
 }

--- a/foundry/app/assets/javascripts/authoring/timeline.js
+++ b/foundry/app/assets/javascripts/authoring/timeline.js
@@ -250,6 +250,7 @@ function redrawTimeline() {
         .style("stroke-width", "2")
 
     //Get the latest time and team status, update x position of cursor
+    cursor = timeline_svg.select(".cursor");
     var latest_time;
     if (in_progress){
         latest_time = (new Date).getTime();
@@ -258,23 +259,10 @@ function redrawTimeline() {
     }
     cursor_details = positionCursor(flashTeamsJSON, latest_time);
 
-    //TODO: REMOVE
-    //Debugging the cursor redrawing
-    cursorDebug();
-    function cursorDebug() {
-        console.log("CURSOR DEBUG INFO!!!!!");
-        console.log("is the team in progress?", in_progress);
-        console.log("cursor_details", cursor_details);
-        console.log("latest_time", latest_time);
-        console.log("END CURSOR DEBUG");
-    }
-
     //move all existing events back on top of timeline
     $(timeline_svg.selectAll('g')).each(function() {
         $('.chart').append(this);
     });
-   
-
 }
 
 //VCom Calculates how many hours to add when user expands timeline manually 

--- a/foundry/app/assets/javascripts/authoring/timeline.js
+++ b/foundry/app/assets/javascripts/authoring/timeline.js
@@ -250,6 +250,24 @@ function redrawTimeline() {
         .style("stroke", "red")
         .style("stroke-width", "2")
 
+    var latest_time;
+    if (in_progress){
+        latest_time = (new Date).getTime();
+    } else {
+        latest_time = loadedStatus.latest_time;
+    }
+    cursor_details = positionCursor(flashTeamsJSON, latest_time);
+    //loadData(in_progress);
+
+    cursorDebug();
+    function cursorDebug() {
+        console.log("CURSOR DEBUG INFO!!!!!");
+        console.log("is the team in progress?", in_progress);
+        console.log("cursor_details", cursor_details);
+        console.log("latest_time", latest_time);
+        console.log("END CURSOR DEBUG");
+    }
+
     //move all existing events back on top of timeline
     $(timeline_svg.selectAll('g')).each(function() {
         $('.chart').append(this);


### PR DESCRIPTION
Whenever we redraw the timeline, redraw cursor, update the cursor var to refer to the cursor, and update its time with positionCursor()

NOTE: want to check that the cursor is correctly position on a new team, a team that was already written but not started, a team that has started and is running for workers and authors, for teams that started and ended

BUG: not related to what broke this OR to this fix, but when you start a team, end it, and refresh, start and end and refresh again (some unclear # of times) the cursor does not position correctly. 
