### PR TITLE
Maggie confirm end team

### DIFF
--- a/foundry/app/assets/javascripts/authoring/awareness.js
+++ b/foundry/app/assets/javascripts/authoring/awareness.js
@@ -91,18 +91,14 @@ $("#flashTeamStartBtn").click(function(){
 
 //Asks user to confirm that they want to end the team
 $("#flashTeamEndBtn").click(function(){
-
-    var currTime = (new Date).getTime();
-    var startTime = flashTeamsJSON["startTime"];
-    var diff = currTime - startTime;
-
-    //console.log("start time: " + startTime);
-    //console.log("current time: " + currTime);
-    //console.log("diff in seconds: " + diff/1000);
-
-    var totalMinutes = findExactMinutes();
-    console.log("total minutes:" + totalMinutes);
-
+    var bodyText = document.getElementById("confirmEndText");
+    if (curr_status_width < 100) {
+        //console.log("ENDED TEAM EARLY");
+        var progressRemaining = Math.round(100 - curr_status_width);
+        bodyText.innerHTML = flashTeamsJSON["title"] + " is still in progress!  Are you sure you want to end " + flashTeamsJSON["title"] + " with " + progressRemaining + "% of progress remaining?";
+    } else {
+        bodyText.innerHTML = "Are you sure you want to end [team name]?";
+    }
     $('#confirmEnd').modal('show');
 });
 

--- a/foundry/app/assets/javascripts/authoring/awareness.js
+++ b/foundry/app/assets/javascripts/authoring/awareness.js
@@ -88,8 +88,21 @@ $("#flashTeamStartBtn").click(function(){
     googleDriveLink();
 });
 
+
 //Asks user to confirm that they want to end the team
 $("#flashTeamEndBtn").click(function(){
+
+    var currTime = (new Date).getTime();
+    var startTime = flashTeamsJSON["startTime"];
+    var diff = currTime - startTime;
+
+    //console.log("start time: " + startTime);
+    //console.log("current time: " + currTime);
+    //console.log("diff in seconds: " + diff/1000);
+
+    var totalMinutes = findExactMinutes();
+    console.log("total minutes:" + totalMinutes);
+
     $('#confirmEnd').modal('show');
 });
 

--- a/foundry/app/assets/javascripts/authoring/awareness.js
+++ b/foundry/app/assets/javascripts/authoring/awareness.js
@@ -88,7 +88,15 @@ $("#flashTeamStartBtn").click(function(){
     googleDriveLink();
 });
 
+//Asks user to confirm that they want to end the team
 $("#flashTeamEndBtn").click(function(){
+    $('#confirmEnd').modal('show');
+});
+
+
+//If user confirms they want to end the team, ends the flash team
+$("#confirmEndTeamBtn").click(function() {
+    $('#confirmEnd').modal('hide');
     updateStatus(false);
     stopCursor();
     stopProjectStatus();

--- a/foundry/app/assets/javascripts/authoring/helper.js
+++ b/foundry/app/assets/javascripts/authoring/helper.js
@@ -110,20 +110,6 @@ function findTotalHours() {
     return totalHours + 2; //THE 2 IS ARBITRARY FOR PADDING
 }
 
-//Find the exact number of minutes from time 0 to the end of the last event
-function findExactMinutes() {
-    var totalMinutes = 0; 
-    for (i = 0; i < flashTeamsJSON["events"].length; i++) {
-        var eventObj = flashTeamsJSON["events"][i];
-        var eventStart = eventObj.startTime;
-        var eventDuration = eventObj.duration;
-        var eventEnd = eventStart + eventDuration;
-        
-        if (eventEnd > totalMinutes) totalMinutes = eventEnd;
-    }
-     
-    return totalMinutes; 
-}
 
 //CALL IN CONSOLE TO HIDE THE CHAT BOX AND PROJECT STATUS
 function hideAwareness() {

--- a/foundry/app/assets/javascripts/authoring/helper.js
+++ b/foundry/app/assets/javascripts/authoring/helper.js
@@ -110,6 +110,21 @@ function findTotalHours() {
     return totalHours + 2; //THE 2 IS ARBITRARY FOR PADDING
 }
 
+//Find the exact number of minutes from time 0 to the end of the last event
+function findExactMinutes() {
+    var totalMinutes = 0; 
+    for (i = 0; i < flashTeamsJSON["events"].length; i++) {
+        var eventObj = flashTeamsJSON["events"][i];
+        var eventStart = eventObj.startTime;
+        var eventDuration = eventObj.duration;
+        var eventEnd = eventStart + eventDuration;
+        
+        if (eventEnd > totalMinutes) totalMinutes = eventEnd;
+    }
+     
+    return totalMinutes; 
+}
+
 //CALL IN CONSOLE TO HIDE THE CHAT BOX AND PROJECT STATUS
 function hideAwareness() {
     var projCont = document.getElementById("project-status-container");

--- a/foundry/app/assets/stylesheets/custom.css
+++ b/foundry/app/assets/stylesheets/custom.css
@@ -1,3 +1,8 @@
+#confirmEnd {
+	color: black;
+	width: 350px;
+}
+
 #memberPills li {
     float: none!important;
     padding: 5px 0;

--- a/foundry/app/views/flash_teams/_confirm_delete.html.erb
+++ b/foundry/app/views/flash_teams/_confirm_delete.html.erb
@@ -1,0 +1,13 @@
+<!-- Confirm delete modal (pops up when user tries to delete a member, event, etc.) -->
+		<div id="confirmDelete" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="Confirm Delete" aria-hidden="true">
+  			<div class="modal-header">
+    			<button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+    			<h3 id="confirmDeleteLabel" align = "center" ></h3>
+  			</div>
+  			<div id = "confirmDeleteText" align = "center" class="modal-body">
+  			</div>
+  			<div class="modal-footer">
+    			<button class="btn" data-dismiss="modal" aria-hidden="true" >Cancel</button> 
+    			<button id= "deleteButton" class="btn btn-danger" ></button>
+  			</div>
+		</div>

--- a/foundry/app/views/flash_teams/_confirm_end.html.erb
+++ b/foundry/app/views/flash_teams/_confirm_end.html.erb
@@ -3,11 +3,11 @@
     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
     <h3 id="myModalLabel" align = "center" >End Team?</h3>
   </div>
-  <div class="modal-body">
-    <p align = "center">Are you sure you want to end <%= @flash_team.name %>?</p>
+  <div class="modal-body" id = "confirmEndText">
+    <p align = "center"></p>
   </div>
   <div class="modal-footer">
     <button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
-    <button class="btn btn-danger" id = "confirmEndTeamBtn">End <%= @flash_team.name %></button>
+    <button class="btn btn-danger" id = "confirmEndTeamBtn">End the team</button>
   </div>
 </div>

--- a/foundry/app/views/flash_teams/_confirm_end.html.erb
+++ b/foundry/app/views/flash_teams/_confirm_end.html.erb
@@ -1,0 +1,13 @@
+<div id="confirmEnd" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="confirmEnd" aria-hidden="true">
+  <div class="modal-header">
+    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+    <h3 id="myModalLabel" align = "center" >End Team?</h3>
+  </div>
+  <div class="modal-body">
+    <p align = "center">Are you sure you want to end <%= @flash_team.name %>?</p>
+  </div>
+  <div class="modal-footer">
+    <button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+    <button class="btn btn-danger" id = "confirmEndTeamBtn">End <%= @flash_team.name %></button>
+  </div>
+</div>

--- a/foundry/app/views/flash_teams/edit.html.erb
+++ b/foundry/app/views/flash_teams/edit.html.erb
@@ -23,6 +23,9 @@
 				<input type="button" class="btn btn-success" id="flashTeamStartBtn" value="Start Team"/>
 		        <input type="button" class="btn btn-danger" id="flashTeamEndBtn" value="End Team" style="display: none"/>
 	     </div>
+
+	     <!-- Render partial with end team confirmation alert -->
+	     <%= render :partial => "confirm_end" %>  
      </div>
      
      <div class="row-fluid" style="margin-top: 40px; margin-bottom: 5px;">


### PR DESCRIPTION
Created the confirmation alert for when the user clicks "end team".  There are two versions of this alert-- one for when the team is ended once all events are complete and one for when the user tries to end the team early.

Right now it looks like the alerts are not updating the team name properly (the team name is New Flash Team for all of them- the default name) BUT the changes in my previous pull request fix this problem so it should work once they are merged =]
