### PR TITLE
Daniela event and member popover delete btn

### DIFF
--- a/foundry/app/assets/javascripts/authoring/members.js
+++ b/foundry/app/assets/javascripts/authoring/members.js
@@ -152,8 +152,8 @@ function renderMemberPopovers(members) {
         content +='</ul>'
         +'Member Color: <input type="text" class="full-spectrum" id="color_' + member_id + '"/>'
         +'<p><script type="text/javascript"> initializeColorPicker(' + newColor +'); </script></p>'
-        +'<p><button class="btn btn-danger" type="button" onclick="deleteMember(' + member_id + ');">Delete</button>     '
-        +'<button class="btn btn-success" type="button" onclick="saveMemberInfo(' + member_id + '); updateStatus();">Save</button>     '
+        +'<p><button class="btn btn-success" type="button" onclick="saveMemberInfo(' + member_id + '); updateStatus();">Save</button>     '
+        +'<button class="btn btn-danger" type="button" onclick="deleteMember(' + member_id + ');">Delete</button>     '
         +'<button class="btn btn-default" type="button" onclick="hideMemberPopover(' + member_id + ');">Cancel</button><br><br>'
         + 'Invitation link: <a id="invitation_link_' + member_id + '" href="' + invitation_link + '" target="_blank">'
         + invitation_link

--- a/foundry/app/assets/javascripts/authoring/members.js
+++ b/foundry/app/assets/javascripts/authoring/members.js
@@ -156,8 +156,9 @@ function renderMemberPopovers(members) {
         +'Member Color: <input type="text" class="full-spectrum" id="color_' + member_id + '"/>'
         +'<p><script type="text/javascript"> initializeColorPicker(' + newColor +'); </script></p>'
 
-        +'<p><button class="btn btn-danger" type="button" onclick="confirmDeleteMember(' + member_id + ');">Delete</button>     '
-        +'<button class="btn btn-success" type="button" onclick="saveMemberInfo(' + member_id + '); updateStatus();">Save</button><br><br>'
+         +'<p><button class="btn btn-success" type="button" onclick="saveMemberInfo(' + member_id + '); updateStatus();">Save</button>      '
+         +'<button class="btn btn-danger" type="button" onclick="confirmDeleteMember(' + member_id + ');">Delete</button>     '
+         +'<button class="btn btn-default" type="button" onclick="hideMemberPopover(' + member_id + ');">Cancel</button><br><br>'
 
         + 'Invitation link: <a id="invitation_link_' + member_id + '" href="' + invitation_link + '" target="_blank">'
         + invitation_link

--- a/foundry/app/assets/javascripts/authoring/popovers.js
+++ b/foundry/app/assets/javascripts/authoring/popovers.js
@@ -66,11 +66,11 @@ function editablePopoverObj(eventObj) {
         + '<div><input type="text" value="' + inputs + '" placeholder="Add input" id="inputs_' + groupNum + '" /></div>'
         + '<div><input type="text" value="' + outputs + '" placeholder="Add output" id="outputs_' + groupNum + '" /></div></div>'
         + '<div class="event-table-row event-table-footer">' 
-        + '<button type="button" class="btn btn-danger" id="delete"'
-        	+' onclick="deleteEvent(' + groupNum +');">Delete</button>       ' 
         + '<button class="btn btn-success" type="button" id="save"'
         	+' onclick="saveEventInfo(' + groupNum + '); hidePopover(' + groupNum + ')">Save</button>       '  
-        + '<button class="btn btn-default" type="button" id="cancel" onclick="hidePopover(' + groupNum + ');">Cancel</button>' 
+        + '<button type="button" class="btn btn-danger" id="delete"'
+        	+' onclick="deleteEvent(' + groupNum +');">Delete</button>       '   
+		+ '<a id="cancel" style="float: right; line-height: 20px; padding-top: 4px; padding-bottom: 4px; margin-top: 2px;" onclick="hidePopover(' + groupNum + ');">Cancel</a>'       
         + '</div>'
         + '</form></div>',
         container: $("#timeline-container"),


### PR DESCRIPTION
I moved the delete buttons on the event and member popovers so they are no longer the first button. On the event popover, I also made cancel a link instead of a button. I left cancel on the member popover as a button for now because it looked a little strange but we might consider fixing that at some point (perhaps when we fix the footer on the member popover).
