### PR TITLE
Replacing members in run time mode.

### DIFF
--- a/foundry/app/assets/javascripts/authoring/awareness.js
+++ b/foundry/app/assets/javascripts/authoring/awareness.js
@@ -252,7 +252,6 @@ var renderChatbox = function(){
 
               // here there once existed a call to boldEvents
               trackUpcomingEvent();
-
             }
          }
         

--- a/foundry/app/assets/javascripts/authoring/awareness.js
+++ b/foundry/app/assets/javascripts/authoring/awareness.js
@@ -153,7 +153,13 @@ $(document).ready(function(){
 			$("#flashTeamStartBtn").css('display','none'); //not sure if this is necessary since it's above 
 			$("#flashTeamEndBtn").css('display',''); //not sure if this is necessary since it's above 
             loadData(true);
-            renderMembersUser();
+             if(!isUser) {
+                    renderMembersRequester();
+                }
+             else{
+                    renderMembersUser();
+                }
+
             startTeam(true);
         } else {
             //console.log("flash team not in progress");
@@ -1111,6 +1117,7 @@ var updateStatus = function(flash_team_in_progress){
     if(flash_team_in_progress != undefined){ // could be undefined if want to call updateStatus in a place where not sure if the team is running or not
         localStatus.flash_team_in_progress = flash_team_in_progress;
     } else {
+      //  alert(in_progress);
         localStatus.flash_team_in_progress = in_progress;
     }
     localStatus.latest_time = (new Date).getTime();

--- a/foundry/app/assets/javascripts/authoring/awareness.js
+++ b/foundry/app/assets/javascripts/authoring/awareness.js
@@ -132,13 +132,15 @@ $(document).ready(function(){
         url: url,
         type: 'get'
     }).done(function(data){
+        
         renderChatbox();
-
+        
         //get user name and user role for the chat
         if(data == null){
             //console.log("RETURNING BEFORE LOAD"); 
             return; // status not set yet
         }
+
         loadedStatus = data;
 
         in_progress = loadedStatus.flash_team_in_progress;
@@ -214,7 +216,7 @@ function listenForVisibilityChange(){
 
 // saves member object for current_user (undefined for author so we will set it to 'Author')
 var current_user;
-
+var showchatnotif;
 //finds user name and sets current variable to user's index in array
 var renderChatbox = function(){
     var uniq_u=getParameterByName('uniq');
@@ -258,6 +260,20 @@ var renderChatbox = function(){
          }
         
        }
+
+
+    
+     // true if notifications should be shown
+       
+    if ((current_user == 'Author' && chat_role == 'Author') || (current_user.uniq == uniq)){
+        showchatnotif = false;
+    }
+    else{
+        showchatnotif = true;
+    }
+  
+
+
     });
 };
 

--- a/foundry/app/assets/javascripts/authoring/members.js
+++ b/foundry/app/assets/javascripts/authoring/members.js
@@ -152,8 +152,9 @@ function renderMemberPopovers(members) {
         content +='</ul>'
         +'Member Color: <input type="text" class="full-spectrum" id="color_' + member_id + '"/>'
         +'<p><script type="text/javascript"> initializeColorPicker(' + newColor +'); </script></p>'
-        +'<p><button class="btn btn-danger" type="button" onclick="deleteMember(' + member_id + ');">Delete</button>     '
-        +'<button class="btn btn-success" type="button" onclick="saveMemberInfo(' + member_id + '); updateStatus();">Save</button>     '
+        +'<p><button class="btn btn-default" type="button" onclick="deleteMember(' + member_id + ');">Delete</button>     '
+        +'<button class="btn btn-default" type="button" onclick="saveMemberInfo(' + member_id + '); updateStatus();">Save</button>     '
+        +'<button class="btn btn-default" type="button" onclick="reInviteMember(' + member_id + '); updateStatus();">Replace</button>     '
         +'<button class="btn btn-default" type="button" onclick="hideMemberPopover(' + member_id + ');">Cancel</button><br><br>'
         + 'Invitation link: <a id="invitation_link_' + member_id + '" href="' + invitation_link + '" target="_blank">'
         + invitation_link
@@ -379,6 +380,29 @@ function inviteMember(pillId) {
         var members = flashTeamsJSON["members"];
         members[indexOfJSON].uniq = data["uniq"];
         members[indexOfJSON].invitation_link = data["url"];
+
+        renderMemberPopovers(members);
+        updateStatus(false);
+    });
+};
+
+function reInviteMember(pillId) {
+
+    var flash_team_id = $("#flash_team_id").val();
+    var url = '/members/' + flash_team_id + '/reInvite';
+    var indexOfJSON = getMemberJSONIndex(pillId);
+    var uniq;
+    var data = {uniq: flashTeamsJSON["members"][indexOfJSON].uniq };
+    $.get(url, data, function(data){
+        //console.log("INVITED MEMBER, NOT RERENDERING MEMBER POPOVER");
+        var members = flashTeamsJSON["members"];
+        members[indexOfJSON].uniq = data["uniq"];
+        members[indexOfJSON].invitation_link = data["url"];
+        //members[indexOfJSON].category1 = "";
+        //members[indexOfJSON].category2 = "";
+        //members[indexOfJSON].skills = [];
+
+
 
         renderMemberPopovers(members);
         updateStatus(false);

--- a/foundry/app/assets/javascripts/authoring/members.js
+++ b/foundry/app/assets/javascripts/authoring/members.js
@@ -392,12 +392,14 @@ function reInviteMember(pillId) {
     var url = '/members/' + flash_team_id + '/reInvite';
     var indexOfJSON = getMemberJSONIndex(pillId);
     var uniq;
+  
     var data = {uniq: flashTeamsJSON["members"][indexOfJSON].uniq };
     $.get(url, data, function(data){
         //console.log("INVITED MEMBER, NOT RERENDERING MEMBER POPOVER");
         var members = flashTeamsJSON["members"];
         members[indexOfJSON].uniq = data["uniq"];
         members[indexOfJSON].invitation_link = data["url"];
+        flashTeamsJSON["members"] = members;
         //members[indexOfJSON].category1 = "";
         //members[indexOfJSON].category2 = "";
         //members[indexOfJSON].skills = [];
@@ -405,7 +407,7 @@ function reInviteMember(pillId) {
 
 
         renderMemberPopovers(members);
-        //updateStatus(false);
+        updateStatus();
     });
 };
 

--- a/foundry/app/assets/javascripts/authoring/members.js
+++ b/foundry/app/assets/javascripts/authoring/members.js
@@ -405,7 +405,7 @@ function reInviteMember(pillId) {
 
 
         renderMemberPopovers(members);
-        updateStatus(false);
+        //updateStatus(false);
     });
 };
 

--- a/foundry/app/assets/javascripts/authoring/sidebar.js
+++ b/foundry/app/assets/javascripts/authoring/sidebar.js
@@ -2,6 +2,7 @@
 
 var myDataRef = new Firebase('https://foundry-ft.firebaseio.com/'+ flash_team_id +'/chats');
 
+
 var currentdate = new Date(); 
 
 var name;
@@ -22,23 +23,17 @@ $('#messageInput').keydown(function(e){
     }
 });
 
-myDataRef.on('child_added', function(snapshot) {
-    var message = snapshot.val();
+myDataRef.once('value', function(snapshot){
     console.log(snapshot);
-    console.log(message);
-    console.log("MESSAGE NAME: " + message["name"]);
-
-    displayChatMessage(message.name, message.uniq, message.role, message.date, message.text);
-    
-    name = message.name;
-});
+})
 
 var lastMessage=0;
 var lastWriter;
 
 function displayChatMessage(name, uniq, role, date, text) {
     
-    if(name == undefined){
+    if(name == undefined ){
+       console.log("!!! chat name is undefined!")
         return;
     }
     
@@ -50,7 +45,7 @@ function displayChatMessage(name, uniq, role, date, text) {
     
     //diff in minutes
     console.log("minutes ago: " + diff/(1000*60)); 
-    
+  /*  
     //notification text   
     //notification title
     var notif_title = name+': '+ text;
@@ -58,7 +53,7 @@ function displayChatMessage(name, uniq, role, date, text) {
     var notif_body = dateform;
     
     var showchatnotif; // true if notifications should be shown
-        
+       
     if ((current_user == 'Author' && role == 'Author') || (current_user.uniq == uniq)){
     	showchatnotif = false;
     }
@@ -72,7 +67,7 @@ function displayChatMessage(name, uniq, role, date, text) {
     if (diff <= 50000 && showchatnotif == true){
 	    notifyMe(notif_title, notif_body, 'chat');
     }
-
+*/
 	//revise condition to include OR if timestamp of last message (e.g., lastDate) was over 10 minutes ago
     if(lastWriter!=name){
         lastMessage=(lastMessage+1)%2;
@@ -89,6 +84,23 @@ function displayChatMessage(name, uniq, role, date, text) {
     lastWriter=name;
     lastDate = message_date;
     $('#messageList')[0].scrollTop = $('#messageList')[0].scrollHeight;
+
+
+            //notification text   
+    //notification title
+    var notif_title = name+': '+ text;
+    //notification body
+    var notif_body = dateform;
+    
+
+    // checks if last notification was less than 5 seconds ago
+    // this is used to only create notifications for messages that were sent from the time you logged in and forward 
+    // (e.g., no notifications for messages in the past)
+    if (diff <= 50000 && showchatnotif == true){
+        notifyMe(notif_title, notif_body, 'chat');
+    }
+
+
 };
 
 
@@ -105,6 +117,29 @@ var userListRef = new Firebase('https://foundry-ft.firebaseio.com/' + flash_team
 
 // Generate a reference to a new location for my user with push.
 var myUserRef = userListRef.push();
+
+/*
+connectedRef.once('value', function(snapshot) {
+    var message = snapshot.val();
+    console.log(snapshot);
+    console.log(message);
+    console.log("MESSAGE NAME: " + message["name"]);
+
+    displayChatMessage(message.name, message.uniq, message.role, message.date, message.text);
+    
+    name = message.name;
+});*/
+
+myDataRef.on('child_added', function(snapshot) {
+    var message = snapshot.val();
+    console.log(snapshot);
+    console.log(message);
+    console.log("MESSAGE NAME: " + message["name"]);
+
+    displayChatMessage(message.name, message.uniq, message.role, message.date, message.text);
+    
+    name = message.name;
+});
 
 connectedRef.on('value', function(snap) {
     if (snap.val() === true) {

--- a/foundry/app/controllers/flash_teams_controller.rb
+++ b/foundry/app/controllers/flash_teams_controller.rb
@@ -36,6 +36,10 @@ class FlashTeamsController < ApplicationController
     @flash_teams = FlashTeam.all.order(:id).reverse_order
   end
 
+rescue_from ActiveRecord::RecordNotFound do
+  #flash[:notice] = 'The object you tried to access does not exist'
+  render 'member_doesnt_exist'   # or e.g. redirect_to :action => :index
+end
  
   def edit
     @flash_team = FlashTeam.find(params[:id])
@@ -58,6 +62,12 @@ class FlashTeamsController < ApplicationController
      @in_author_view = false
 
      uniq = params[:uniq]
+    
+     Member.find_by! uniq: uniq
+     #if !(Member.exist(:uniq => uniq))  #role has been reinvited and doesn't exist anymore
+     #   render 'member_doesnt_exist'
+     #end 
+
      member = Member.where(:uniq => uniq)[0]
      @user_name = member.name
 

--- a/foundry/app/controllers/members_controller.rb
+++ b/foundry/app/controllers/members_controller.rb
@@ -21,20 +21,20 @@ class MembersController < ApplicationController
   def reInvite
 
     prev_uniq = params[:uniq]
-    
-
     uniq = SecureRandom.uuid
     
 
     member = Member.where(:uniq => prev_uniq)[0]
-    member.name = nil
-    member.color = nil
-    member.email = nil
-    member.confirm_email_uniq = nil
-    member.email_confirmed = nil
-    member.uniq = nil
-    member.save
-
+    if member  != nil
+      member.name = nil
+      member.color = nil
+      member.email = nil
+      member.confirm_email_uniq = nil
+      member.email_confirmed = nil
+      member.uniq = nil
+      member.save
+    end
+    
     # generate unique id and add to url below
     url = url_for :action => 'invited', :id => params[:id], :uniq => uniq
     

--- a/foundry/app/controllers/members_controller.rb
+++ b/foundry/app/controllers/members_controller.rb
@@ -2,10 +2,38 @@ require 'json'
 
 class MembersController < ApplicationController
   def invite
+
     uniq = params[:uniq]
     if !uniq
       uniq = SecureRandom.uuid
     end
+
+    # generate unique id and add to url below
+    url = url_for :action => 'invited', :id => params[:id], :uniq => uniq
+    
+    #UserMailer.send_email(email, url).deliver
+
+    respond_to do |format|
+      format.json {render json: {:url => url, :uniq => uniq}.to_json, status: :ok}
+    end
+  end
+
+  def reInvite
+
+    prev_uniq = params[:uniq]
+    
+
+    uniq = SecureRandom.uuid
+    
+
+    member = Member.where(:uniq => prev_uniq)[0]
+    member.name = nil
+    member.color = nil
+    member.email = nil
+    member.confirm_email_uniq = nil
+    member.email_confirmed = nil
+    member.uniq = nil
+    member.save
 
     # generate unique id and add to url below
     url = url_for :action => 'invited', :id => params[:id], :uniq => uniq

--- a/foundry/app/views/flash_teams/member_doesnt_exist.html.erb
+++ b/foundry/app/views/flash_teams/member_doesnt_exist.html.erb
@@ -1,0 +1,1 @@
+Your link to Foundry is not active any more. Please contact the author if your link has been deactivated by mistake.

--- a/foundry/config/routes.rb
+++ b/foundry/config/routes.rb
@@ -83,6 +83,7 @@ Foundry::Application.routes.draw do
   resources :members do
     member do
       get :invite
+      get :reInvite
       get :invited
       get :confirm_email
       post :register


### PR DESCRIPTION
-Added a replace button to members popover. Clicking on the replace button resets the invitation link and deactivates the previous user's unique link to Foundry.
This feature should be tested both in run time mode and static modes.
-Fixed bug. The members should show up on author's page in run time even after the page is reloaded.
- Fixed bug. Sometimes, the previous chat script didn't show up in the chat when a new user opened her unique page.
