### PR TITLE
fix bug. chat notifications.

### DIFF
--- a/foundry/app/assets/javascripts/authoring/notifications.js
+++ b/foundry/app/assets/javascripts/authoring/notifications.js
@@ -1,16 +1,14 @@
  var last_notification = null;
 
 function notifyMe(notif_title, notif_body, notif_tag) {
-   
   // Let's check if the browser supports notifications
   if (!("Notification" in window)) {
     alert("This browser does not support desktop notification");
   }
   
   // Let's check if the user is okay to get some notification
-  else if (Notification.permission === "granted") {
+  else if (Notification.permission === "granted" || Notification.permission === "default") {
     // If it's okay let's create a notification
-    
 	showNotif(notif_title, notif_body, notif_tag);
   }
 
@@ -39,7 +37,6 @@ function notifyMe(notif_title, notif_body, notif_tag) {
 }
 
 function showNotif(notif_title, notif_body, notif_tag){
-	
 	closeNotif(last_notification); //close any notifications that might exist from previous sessions
 	
 	var notification = new Notification(notif_title, {body: notif_body, tag: notif_tag});

--- a/foundry/app/assets/javascripts/authoring/notifications.js
+++ b/foundry/app/assets/javascripts/authoring/notifications.js
@@ -7,22 +7,22 @@ function notifyMe(notif_title, notif_body, notif_tag) {
   }
   
   // Let's check if the user is okay to get some notification
-  else if (Notification.permission === "granted" || Notification.permission === "default") {
+  else if (Notification.permission === "granted") {
     // If it's okay let's create a notification
 	showNotif(notif_title, notif_body, notif_tag);
   }
+
 
   // Otherwise, we need to ask the user for permission
   // Note, Chrome does not implement the permission static property
   // So we have to check for NOT 'denied' instead of 'default'
   else if (Notification.permission !== 'denied') {
     Notification.requestPermission(function (permission) {
-
+  
       // Whatever the user answers, we make sure we store the information
       if(!('permission' in Notification)) {
         Notification.permission = permission;
       }
-
       // If the user is okay, let's create a notification
       if (permission === "granted") {
 		showNotif(notif_title, notif_body, notif_tag);

--- a/foundry/app/assets/javascripts/authoring/sidebar.js
+++ b/foundry/app/assets/javascripts/authoring/sidebar.js
@@ -68,7 +68,7 @@ function displayChatMessage(name, uniq, role, date, text) {
     //notification body
     var notif_body = dateform;
     
-    var showchatnotif; // true if notifications should be shown
+    var showchatnotif = false; // true if notifications should be shown
         
     if ((current_user == 'Author' && role == 'Author') || (current_user.uniq == uniq)){
     	showchatnotif = false;
@@ -81,6 +81,7 @@ function displayChatMessage(name, uniq, role, date, text) {
     // this is used to only create notifications for messages that were sent from the time you logged in and forward 
     // (e.g., no notifications for messages in the past)
     if (diff <= 50000 && showchatnotif == true){
+        playSound("/assets/notify");
 	    notifyMe(notif_title, notif_body, 'chat');
     }
 


### PR DESCRIPTION
@dretelny notifications worked in firefox but not in chrome on my laptop. Although the API website indicates that chrome should support it! 

I relocated the sound function so that the notification sounds work whether or not the actual notifications show up.  Chrome has another API for notifications. But I am not sure if it is worth to spend more time on this issue. Feel free to merge this if you agree.
