### PR TITLE
Duplicate Teams [bad status issue still]

### DIFF
--- a/foundry/Gemfile.lock
+++ b/foundry/Gemfile.lock
@@ -170,7 +170,6 @@ PLATFORMS
 
 DEPENDENCIES
   bootstrap-sass-rails
-  coffee-rails (~> 4.0.0)
   d3-rails
   google-api-client
   jbuilder (~> 1.2)

--- a/foundry/app/controllers/flash_teams_controller.rb
+++ b/foundry/app/controllers/flash_teams_controller.rb
@@ -32,6 +32,21 @@ class FlashTeamsController < ApplicationController
     @flash_team = FlashTeam.find(params[:id])
   end
 
+  def duplicate
+    # Locate data from the original
+    original = FlashTeam.find(params[:id])
+
+    # Then create a copy from the original data
+    copy = FlashTeam.create(:name => original.name + " Copy")
+    copy.json = '{"title": "' + copy.name + '","id": ' + copy.id.to_s + ',"events": [],"members": [],"interactions": []}'
+    copy.status = original.status
+    copy.save
+
+    # Redirect to the list of things
+    redirect_to :action => 'index'
+  end
+
+
   def index
     @flash_teams = FlashTeam.all.order(:id).reverse_order
   end

--- a/foundry/app/views/flash_teams/index.html.erb
+++ b/foundry/app/views/flash_teams/index.html.erb
@@ -23,8 +23,8 @@
       <!-- <td><%= flash_team.name %></td> -->
       <!-- <td><%= link_to 'Show', flash_team %></td> -->
       <td><%= link_to 'Edit', edit_flash_team_path(flash_team) %></td>
-	  <td><%= link_to 'Delete', flash_team_path(flash_team), :method => :delete, :confirm => 'Are you sure?' %></td>
-
+  	  <td><%= link_to 'Delete', flash_team_path(flash_team), :method => :delete, :confirm => 'Are you sure?' %></td>
+      <td><%= link_to 'Duplicate', duplicate_flash_team_path(flash_team) %></td>
     </tr>
   <% end %>
   </tbody>

--- a/foundry/config/routes.rb
+++ b/foundry/config/routes.rb
@@ -74,6 +74,9 @@ Foundry::Application.routes.draw do
       post :get_user_name
       post :delayed_task_finished_email
       post :create
+      get :settings
+      get :duplicate
+      post :settings
     end
   end
 


### PR DESCRIPTION
Duplicates the JSON and status of a team and into the team library. Although everything copies over well, eventually we want to change the line that says: copy.status = original.status in the controller and save a non-started status. This is not very simple, so we keep it as is for now. 

Another solution is to default "copy" all teams before you press start - this requires more re-design, etc. 

For the tester: check to make sure the team copies everything over (members, details for members, events, details for each event, and interactions). If you choose, you can try to run the duplicated team and then duplicate it and observe the 'copied status' issue. 
To be really robust, you can also check to make sure we did not corrupt the original team by duplicating it. 
