### PR TITLE
30 minute tasks

### DIFF
--- a/foundry/app/assets/javascripts/authoring/events.js
+++ b/foundry/app/assets/javascripts/authoring/events.js
@@ -540,7 +540,7 @@ function drawHandoffBtn(eventObj, firstTime) {
     }
 
     var x_offset = getWidth(eventObj)-18; // unique for handoff btn
-    var y_offset = 23; // unique for handoff btn
+    var y_offset = 46; // unique for handoff btn
 
     var groupNum = eventObj["id"];
     var task_g = getTaskGFromGroupNum(groupNum);
@@ -582,7 +582,7 @@ function drawCollabBtn(eventObj, firstTime) {
     if(isUser || in_progress){ return; }
 
     var x_offset = getWidth(eventObj)-38; // unique for collab btn
-    var y_offset = 23; // unique for collab btn
+    var y_offset = 46; // unique for collab btn
 
     var groupNum = eventObj["id"];
     var task_g = getTaskGFromGroupNum(groupNum);

--- a/foundry/app/assets/javascripts/authoring/events.js
+++ b/foundry/app/assets/javascripts/authoring/events.js
@@ -540,7 +540,7 @@ function drawHandoffBtn(eventObj, firstTime) {
     }
 
     var x_offset = getWidth(eventObj)-18; // unique for handoff btn
-    var y_offset = 46; // unique for handoff btn
+    var y_offset = 40; // unique for handoff btn
 
     var groupNum = eventObj["id"];
     var task_g = getTaskGFromGroupNum(groupNum);
@@ -582,7 +582,7 @@ function drawCollabBtn(eventObj, firstTime) {
     if(isUser || in_progress){ return; }
 
     var x_offset = getWidth(eventObj)-38; // unique for collab btn
-    var y_offset = 46; // unique for collab btn
+    var y_offset = 40; // unique for collab btn
 
     var groupNum = eventObj["id"];
     var task_g = getTaskGFromGroupNum(groupNum);

--- a/foundry/app/assets/javascripts/authoring/events.js
+++ b/foundry/app/assets/javascripts/authoring/events.js
@@ -444,7 +444,11 @@ function drawDurationText(eventObj, firstTime) {
     if(existingDurationText[0].length == 0){ // first time
         task_g.append("text")
             .text(function (d) {
-                return numHoursInt+"hrs "+minutesLeft+"min";
+                if (numHoursInt == 0){
+                    return minutesLeft+"min";
+                }
+                else
+                    return numHoursInt+"hrs "+minutesLeft+"min";
             })
             .attr("class", "time_text")
             .attr("id", function(d) {return "time_text_" + groupNum;})
@@ -455,7 +459,11 @@ function drawDurationText(eventObj, firstTime) {
     } else {
         task_g.selectAll(".time_text")
             .text(function (d) {
-                return numHoursInt+"hrs "+minutesLeft+"min";
+                if (numHoursInt == 0){
+                    return minutesLeft+"min"; 
+                }
+                else
+                    return numHoursInt+"hrs "+minutesLeft+"min";
             })
             .attr("x", function(d) {return d.x + x_offset})
             .attr("y", function(d) {return d.y + y_offset});

--- a/foundry/app/assets/javascripts/authoring/events.js
+++ b/foundry/app/assets/javascripts/authoring/events.js
@@ -415,6 +415,25 @@ function drawTitleText(eventObj, firstTime) {
     var title = eventObj["title"];
     var task_g = getTaskGFromGroupNum(groupNum);
 
+    //shorten title to fit inside event
+    var existingTitleTextDiv = document.getElementById("TitleLength");
+    existingTitleTextDiv.innerHTML = title;
+    var shortened_title = title;
+    var width = (existingTitleTextDiv.clientWidth );
+    var event_width = getWidth(eventObj);
+     
+  while (width > event_width - 15){ 
+         shortened_title = shortened_title.substring(0,shortened_title.length - 4);
+        shortened_title = shortened_title + "...";
+       
+        console.log(shortened_title);
+        existingTitleTextDiv.innerHTML = shortened_title;
+        width = (existingTitleTextDiv.clientWidth);
+  }
+
+    title = shortened_title;
+   
+
     var existingTitleText = task_g.selectAll("#title_text_" + groupNum);
     if(existingTitleText[0].length == 0){ // first time
         task_g.append("text")
@@ -432,6 +451,8 @@ function drawTitleText(eventObj, firstTime) {
             .attr("x", function(d) {return d.x + x_offset})
             .attr("y", function(d) {return d.y + y_offset});
     }
+
+
 }
 
 function drawDurationText(eventObj, firstTime) {
@@ -929,3 +950,9 @@ function deleteEvent(eventId){
     
     updateStatus(false);
 }
+
+//This function is used to truncate the event title string since html tags cannot be attached to svg
+String.prototype.trunc = String.prototype.trunc ||
+      function(n){
+         // return this.length>n ? this.substr(0,n-1)+'...' : this;
+      };

--- a/foundry/app/assets/javascripts/authoring/events.js
+++ b/foundry/app/assets/javascripts/authoring/events.js
@@ -78,7 +78,9 @@ function leftResize(d) {
         newX = 0;
     }
     var newWidth = width + (ev.x - newX);
-
+    if (newWidth < 30)
+        return;
+    
     // update x and draw event
     ev.x = newX;
     ev.min_x = newX;
@@ -99,6 +101,7 @@ function rightResize(d) {
         return;
     }
 
+
     // get event id
     var groupNum = d.groupNum;
 
@@ -110,6 +113,8 @@ function rightResize(d) {
         newX = SVG_WIDTH;
     }
     var newWidth = newX - ev.x;
+    if (newWidth < 30)
+        return;
 
     ev.duration = durationForWidth(newWidth);
 

--- a/foundry/app/assets/javascripts/authoring/popovers.js
+++ b/foundry/app/assets/javascripts/authoring/popovers.js
@@ -54,7 +54,7 @@ function editablePopoverObj(eventObj) {
             + '" min="0" step="15" max="45" style="width:35px"><br />'
         + '<b>Total Runtime: </b> <br />' 
         + 'Hours: <input type = "number" id="hours_' + groupNum + '" placeholder="'
-            +numHours+'" min="2" style="width:35px"/>         ' 
+            +numHours+'" min="0" style="width:35px"/>         ' 
         + 'Minutes: <input type = "number" id = "minutes_' + groupNum + '" placeholder="'+minutesLeft
             +'" style="width:35px" min="0" step="15" max="45"/> <br />'
         + '<b>Members</b><br /> <div id="event' + groupNum + 'memberList">'
@@ -269,6 +269,7 @@ function saveEventInfo (popId) {
     var startHour = $("#startHr_" + popId).val();    
     if (startHour == "") startHour = parseInt($("#startHr_" + popId).attr("placeholder"));
     var startMin = $("#startMin_" + popId).val();
+
     if (startMin == "") startMin = parseInt($("#startMin_" + popId).attr("placeholder"));
     //newX
     startHour = parseInt(startHour);
@@ -301,6 +302,11 @@ function saveEventInfo (popId) {
     if (newHours == "") newHours = parseInt($("#hours_" + popId)[0].placeholder);
     if (newMin == "") newMin = parseInt($("#minutes_" + popId)[0].placeholder);
     newMin = Math.round(parseInt(newMin)/15) * 15;
+    
+    //cannot have events shorter than 30 minutes
+    if (newHours == 0 && newMin == 15){
+        newMin = 30;
+    }
     var newWidth = (newHours * 100) + (newMin/15*25);
   
     //Update JSON

--- a/foundry/app/assets/stylesheets/custom.css
+++ b/foundry/app/assets/stylesheets/custom.css
@@ -156,3 +156,14 @@ in flash_teams.css.scss? */
 #gFolder {
     cursor:pointer;
 }
+
+
+#TitleLength
+{
+    position: absolute;
+    visibility: hidden;
+    height: auto;
+    width: auto;
+    font-weight: bold;
+    font-size: 12px;
+}

--- a/foundry/app/views/flash_teams/edit.html.erb
+++ b/foundry/app/views/flash_teams/edit.html.erb
@@ -2,6 +2,7 @@
 <input type="hidden" id="flash_team_id" value="<%= @flash_team.id %>"/>
 <input type="hidden" id="flash_team_name" value="<%= @flash_team.name%>"/>
 <input type="hidden" id="uniq" value=""/>
+<div id="TitleLength"></div>
 
 <%= tag :meta, :name=> 'events_json', :content=> @events_json %>
 


### PR DESCRIPTION
- Cannot have events shorter than 30 minutes.
- The duration text on events less than 1 hour are shortened.
- The title is truncated if it is longer than the event width. Html tags cannot get attached to the svg so I had to shorten the title string in the JavaScript and draw it on the event rather than using ellipsis CSS. 

-The hand off and collaboration buttons are drawn at a lower vertical position on the event so that they don't hide the upload link on short tasks. 
