### PR TITLE
Dr dup team

### DIFF
--- a/foundry/app/assets/javascripts/authoring/awareness.js
+++ b/foundry/app/assets/javascripts/authoring/awareness.js
@@ -218,6 +218,12 @@ function renderEverything(firstTime) {
             startTeam(firstTime);
         } else {
             console.log("flash team not in progress");
+            
+            if(flashTeamsJSON["startTime"] == undefined){
+	            //console.log("NO START TIME!");
+				updateOriginalStatus();
+            }
+            
             if(!flashTeamsJSON)
                 return;
             
@@ -460,10 +466,12 @@ var startTeam = function(firstTime){
     console.log("STARTING TEAM");
 
     if(!in_progress) {
-        flashTeamsJSON["original_json"] = JSON.parse(JSON.stringify(flashTeamsJSON));
-        flashTeamsJSON["original_status"] = JSON.parse(JSON.stringify(loadedStatus));
-        console.log("flashTeamsJSON['original_json']: " + flashTeamsJSON["original_json"]);
-        console.log("flashTeamsJSON['original_status']: " + flashTeamsJSON["original_status"]);
+        //flashTeamsJSON["original_json"] = JSON.parse(JSON.stringify(flashTeamsJSON));
+        //flashTeamsJSON["original_status"] = JSON.parse(JSON.stringify(loadedStatus));
+        //console.log("flashTeamsJSON['original_json']: " + flashTeamsJSON["original_json"]);
+        //console.log("flashTeamsJSON['original_status']: " + flashTeamsJSON["original_status"]);
+        //updateStatus();
+        updateOriginalStatus();
 		recordStartTime();
         addAllFolders();
         in_progress = true; // TODO: set before this?
@@ -1343,6 +1351,13 @@ var constructStatusObj = function(){
 var updateStatus = function(flash_team_in_progress){
     console.log("in updateStatus");
     var localStatus = constructStatusObj();
+    
+    //if flashTeam hasn't been started yet, update the original status in the db
+    if(flashTeamsJSON["startTime"] == undefined){
+	    //console.log("NO START TIME!");    
+		updateOriginalStatus();
+    }
+
     if(flash_team_in_progress != undefined){ // could be undefined if want to call updateStatus in a place where not sure if the team is running or not
         localStatus.flash_team_in_progress = flash_team_in_progress;
     } else {
@@ -1356,6 +1371,29 @@ var updateStatus = function(flash_team_in_progress){
     var flash_team_id = $("#flash_team_id").val();
     var authenticity_token = $("#authenticity_token").val();
     var url = '/flash_teams/' + flash_team_id + '/update_status';
+    $.ajax({
+        url: url,
+        type: 'post',
+        data: {"localStatusJSON": localStatusJSON, "authenticity_token": authenticity_token}
+    }).done(function(data){
+        //console.log("UPDATED FLASH TEAM STATUS");
+    });
+};
+
+//this function updates the original status of the flash team in the database, which is 
+// used for the team duplication feature (it preserves the team without saving the status 
+// information once the team is run
+var updateOriginalStatus = function(){
+    console.log("in updateOriginalStatus");
+    var localStatus = constructStatusObj();
+
+    localStatus.latest_time = (new Date).getTime();
+    var localStatusJSON = JSON.stringify(localStatus);
+    //console.log("updating string: " + localStatusJSON);
+
+    var flash_team_id = $("#flash_team_id").val();
+    var authenticity_token = $("#authenticity_token").val();
+    var url = '/flash_teams/' + flash_team_id + '/update_original_status';
     $.ajax({
         url: url,
         type: 'post',

--- a/foundry/app/assets/javascripts/authoring/awareness.js
+++ b/foundry/app/assets/javascripts/authoring/awareness.js
@@ -460,7 +460,11 @@ var startTeam = function(firstTime){
     console.log("STARTING TEAM");
 
     if(!in_progress) {
-        recordStartTime();
+        flashTeamsJSON["original_json"] = JSON.parse(JSON.stringify(flashTeamsJSON));
+        flashTeamsJSON["original_status"] = JSON.parse(JSON.stringify(loadedStatus));
+        console.log("flashTeamsJSON['original_json']: " + flashTeamsJSON["original_json"]);
+        console.log("flashTeamsJSON['original_status']: " + flashTeamsJSON["original_status"]);
+		recordStartTime();
         addAllFolders();
         in_progress = true; // TODO: set before this?
     }

--- a/foundry/app/assets/javascripts/authoring/helper.js
+++ b/foundry/app/assets/javascripts/authoring/helper.js
@@ -9,10 +9,10 @@ var flashTeamsJSON = {
     "id" : 1,
     "events": [],        //{"title", "id", "startTime", "duration", "notes", "members": [], "dri", "yPosition", inputs”:[], “outputs”:[]}
     "members": [],       //{"id", "role", "skills":[], "color", "category1", "category2"}
-
     "interactions" : [],  //{"event1", "event2", "type", "description", "id"}
-    "author": "defaultAuthor"
-
+    "author": "defaultAuthor",
+    "original_status": "original status",
+    "original_json": "original json"
 };
 
 function pressEnterKeyToSubmit(inputId, buttonId) {

--- a/foundry/app/controllers/flash_teams_controller.rb
+++ b/foundry/app/controllers/flash_teams_controller.rb
@@ -43,7 +43,10 @@ class FlashTeamsController < ApplicationController
     # Then create a copy from the original data
     copy = FlashTeam.create(:name => original.name + " Copy", :author => original.author)
     copy.json = '{"title": "' + copy.name + '","id": ' + copy.id.to_s + ',"events": [],"members": [],"interactions": [], "author": "' + copy.author + '"}'
-    copy.status = original.status
+    
+    # Use the original_status of the original flash team when copying to prevent copying over the status information of teams that were already started
+    copy.status = original.original_status
+    #copy.status = original.status
     copy.save
 
     # Redirect to the list of things
@@ -151,6 +154,17 @@ end
     status = params[:localStatusJSON]
     @flash_team = FlashTeam.find(params[:id])
     @flash_team.status = status
+    @flash_team.save
+
+    respond_to do |format|
+      format.json {render json: "saved".to_json, status: :ok}
+    end
+  end
+  
+  def update_original_status
+    status = params[:localStatusJSON]
+    @flash_team = FlashTeam.find(params[:id])
+    @flash_team.original_status = status
     @flash_team.save
 
     respond_to do |format|

--- a/foundry/config/routes.rb
+++ b/foundry/config/routes.rb
@@ -68,6 +68,7 @@ Foundry::Application.routes.draw do
       delete :destroy
       get :get_status
       post :update_status
+      post :update_original_status
       post :update_json
       get :get_json
       post :early_completion_email

--- a/foundry/db/migrate/20140729170357_add_original_status_to_flash_teams.rb
+++ b/foundry/db/migrate/20140729170357_add_original_status_to_flash_teams.rb
@@ -1,0 +1,5 @@
+class AddOriginalStatusToFlashTeams < ActiveRecord::Migration
+  def change
+    add_column :flash_teams, :original_status, :text
+  end
+end

--- a/foundry/db/schema.rb
+++ b/foundry/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20131127015448) do
+ActiveRecord::Schema.define(version: 20140729170357) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 20131127015448) do
     t.text     "notification_email_status"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.text     "original_status"
   end
 
   create_table "handoffs", force: true do |t|
@@ -55,6 +56,16 @@ ActiveRecord::Schema.define(version: 20131127015448) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "sessions", force: true do |t|
+    t.string   "session_id", null: false
+    t.text     "data"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", unique: true, using: :btree
+  add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
 
   create_table "skills", force: true do |t|
     t.string   "name"
@@ -76,6 +87,12 @@ ActiveRecord::Schema.define(version: 20131127015448) do
     t.integer  "end_minute"
     t.integer  "duration"
     t.text     "description"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "users", force: true do |t|
+    t.string   "username"
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/foundry/db/schema.rb
+++ b/foundry/db/schema.rb
@@ -57,16 +57,6 @@ ActiveRecord::Schema.define(version: 20140729170357) do
     t.datetime "updated_at"
   end
 
-  create_table "sessions", force: true do |t|
-    t.string   "session_id", null: false
-    t.text     "data"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", unique: true, using: :btree
-  add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
-
   create_table "skills", force: true do |t|
     t.string   "name"
     t.datetime "created_at"
@@ -87,12 +77,6 @@ ActiveRecord::Schema.define(version: 20140729170357) do
     t.integer  "end_minute"
     t.integer  "duration"
     t.text     "description"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "users", force: true do |t|
-    t.string   "username"
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
I fixed the duplicate team feature so that you can duplicate teams that have been started without copying over the status information. To do this, I added a column to the flash team database that saves the team's original status. Then I call updateOriginalStatus in three places: 

1) In render everything (only when team hasn't been started)
2) In StartTeam (right before recording the team's start time)
3) in UpdateStatus (only when team hasn't been started)

When checking, make sure team gets copied over correctly by testing as many use cases as possible including:

1) before team has been created
2) after starting team
3) after team has ended 
4) complex teams with handoffs, many members, etc. 
5) anything else you can think of 

Also make sure the other team info gets copied over correctly (team name, etc.) I didn't change how we copied over the json info so that should be fine. 
