### PR TITLE
Added start team alert and fixed colors of confirm buttons for all alert...

### DIFF
--- a/foundry/app/assets/javascripts/authoring/awareness.js
+++ b/foundry/app/assets/javascripts/authoring/awareness.js
@@ -81,6 +81,24 @@ function removeHandoffBtns(){
 };
 
 $("#flashTeamStartBtn").click(function(){
+    var bodyText = document.getElementById("confirmActionText");
+    //updateStatus();
+    bodyText.innerHTML = "Are you sure you want to begin running " + flashTeamsJSON["title"] + "?";
+    
+    var confirmStartTeamBtn = document.getElementById("confirmButton");
+    confirmStartTeamBtn.innerHTML = "Start the team";
+    
+    $("#confirmButton").attr("class","btn btn-success");
+    var label = document.getElementById("confirmActionLabel");
+    label.innerHTML = "Start Team?";
+    $('#confirmAction').modal('show');
+
+    document.getElementById("confirmButton").onclick=function(){startFlashTeam()};
+    
+});
+
+function startFlashTeam() {
+    $('#confirmAction').modal('hide');
     // view changes
     $("#flashTeamStartBtn").attr("disabled", "disabled");
     $("#flashTeamStartBtn").css('display','none');
@@ -93,7 +111,7 @@ $("#flashTeamStartBtn").click(function(){
     removeHandoffBtns();
     startTeam(true);
     googleDriveLink();
-});
+}
 
 
 function endTeam() {
@@ -120,6 +138,7 @@ $("#flashTeamEndBtn").click(function(){
     }
     var confirmEndTeamBtn = document.getElementById("confirmButton");
     confirmEndTeamBtn.innerHTML = "End the team";
+    $("#confirmButton").attr("class","btn btn-danger");
     var label = document.getElementById("confirmActionLabel");
     label.innerHTML = "End Team?";
     $('#confirmAction').modal('show');
@@ -1441,6 +1460,7 @@ function confirmCompleteTask(groupNum) {
 
     var completeButton = document.getElementById("confirmButton");
     completeButton.innerHTML = "Complete event";
+    $("#confirmButton").attr("class","btn btn-success");
 
     $('#confirmAction').modal('show');
     

--- a/foundry/app/assets/javascripts/authoring/events.js
+++ b/foundry/app/assets/javascripts/authoring/events.js
@@ -904,6 +904,7 @@ function confirmDeleteEvent(eventId) {
 
     var deleteButton = document.getElementById("confirmButton");
     deleteButton.innerHTML = "Delete event";
+    $("#confirmButton").attr("class","btn btn-danger");
 
     $('#confirmAction').modal('show');
     

--- a/foundry/app/assets/javascripts/authoring/members.js
+++ b/foundry/app/assets/javascripts/authoring/members.js
@@ -353,6 +353,7 @@ function confirmDeleteMember(pillId) {
 
     var deleteButton = document.getElementById("confirmButton");
     deleteButton.innerHTML = "Remove member";
+    $("#confirmButton").attr("class","btn btn-danger");
 
     $('#confirmAction').modal('show');
 


### PR DESCRIPTION
...s

Two very small additions here:
1. Added an alert for starting the team.  Works the same/shares the same code as all the other alerts.
2. Customized the button type for each alert (danger/success/etc.)

Testing should be fairly simple.  Just test all the alerts (start team, end team, remove member, delete event, complete event) and make sure that the action buttons look appropriate (i.e. red button for deleting things, green button for starting things, etc).

Make sure that none of the alerts get mixed up (i.e. start team actually ends the team or something like that).
