### PR TITLE
fixed the issue that delayed tasks were moving back on reload

### DIFF
--- a/foundry/app/assets/javascripts/authoring/awareness.js
+++ b/foundry/app/assets/javascripts/authoring/awareness.js
@@ -684,7 +684,9 @@ var drawDelayedTasks = function(){
     if (tasks_after != null){
         var actual_offset = computeTotalOffset(allRanges);
         console.log("DRAWING DELAYED TASKS AFTER UPDATE");
-        moveTasksRight(tasks_after, actual_offset, true);
+        
+        //note from DR: this was previous true but it was causing the delayed task issue to occur (changing it to false fixed the issue)
+        moveTasksRight(tasks_after, actual_offset, false); 
     }
 };
 


### PR DESCRIPTION
This should fix the issue that was causing delayed tasks to push back on reload. When two tasks are touching, the second one doesn't always get pushed back but this fix seemed to always work when tasks were 15 minutes apart. When checking this, you might want to make sure that my change in the code (e.g., changing the moveTaskRight parameter the second time it gets called from true to false) didn't mess anything else up. I'm not sure why it was true to begin with. Please do a thorough check in both author and worker view. 
